### PR TITLE
Introduce Timeouts & TimeoutsBuilder

### DIFF
--- a/src/main/java/com/eventstore/dbclient/Timeouts.java
+++ b/src/main/java/com/eventstore/dbclient/Timeouts.java
@@ -1,0 +1,15 @@
+package com.eventstore.dbclient;
+
+import java.util.concurrent.TimeUnit;
+
+public class Timeouts {
+    final long shutdownTimeout;
+    final TimeUnit shutdownTimeoutUnit;
+
+    public static final Timeouts DEFAULT = new Timeouts(1, TimeUnit.SECONDS);
+
+    Timeouts(final long shutdownTimeout, final TimeUnit shutdownTimeoutUnit) {
+        this.shutdownTimeout = shutdownTimeout;
+        this.shutdownTimeoutUnit = shutdownTimeoutUnit;
+    }
+}

--- a/src/main/java/com/eventstore/dbclient/TimeoutsBuilder.java
+++ b/src/main/java/com/eventstore/dbclient/TimeoutsBuilder.java
@@ -1,0 +1,25 @@
+package com.eventstore.dbclient;
+
+import java.util.concurrent.TimeUnit;
+
+public class TimeoutsBuilder {
+    long shutdownTimeout;
+    TimeUnit shutdownTimeoutUnit;
+
+    public static TimeoutsBuilder newBuilder() {
+        TimeoutsBuilder builder = new TimeoutsBuilder();
+        builder.shutdownTimeout = Timeouts.DEFAULT.shutdownTimeout;
+        builder.shutdownTimeoutUnit = Timeouts.DEFAULT.shutdownTimeoutUnit;
+        return builder;
+    }
+
+    public TimeoutsBuilder withShutdownTimeout(final long timeout, final TimeUnit timeoutUnit) {
+        shutdownTimeout = timeout;
+        shutdownTimeoutUnit = timeoutUnit;
+        return this;
+    }
+
+    public Timeouts build() {
+        return new Timeouts(shutdownTimeout, shutdownTimeoutUnit);
+    }
+}

--- a/src/test/java/testcontainers/module/EventStoreTestDBContainer.java
+++ b/src/test/java/testcontainers/module/EventStoreTestDBContainer.java
@@ -1,6 +1,7 @@
 package testcontainers.module;
 
 import com.eventstore.dbclient.StreamsClient;
+import com.eventstore.dbclient.Timeouts;
 import com.eventstore.dbclient.UserCredentials;
 import com.github.dockerjava.api.model.HealthCheck;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
@@ -57,8 +58,9 @@ public class EventStoreTestDBContainer extends GenericContainer<EventStoreTestDB
         final int port = getMappedPort(DB_HTTP_PORT);
         final SslContext sslContext = getClientSslContext();
         final UserCredentials creds = new UserCredentials("admin", "changeit");
+        final Timeouts timeouts = Timeouts.DEFAULT;
 
-        return new StreamsClient(address, port, creds, sslContext);
+        return new StreamsClient(address, port, creds, timeouts, sslContext);
     }
 
     private SslContext getClientSslContext() {


### PR DESCRIPTION
This commit introduces a new class, `Timeouts` which must be passed to instances of `StreamsClient`. A static final `DEFAULT` instance can be passed in place of defining custom timeouts. A TimeoutsBuilder object provides an extensible way to build this value as new operations which require timeouts get added, without breaking forwards compatibility.