### PR TITLE
Add test for TimeoutsBuilder

### DIFF
--- a/src/main/java/com/eventstore/dbclient/TimeoutsBuilder.java
+++ b/src/main/java/com/eventstore/dbclient/TimeoutsBuilder.java
@@ -22,4 +22,8 @@ public class TimeoutsBuilder {
     public Timeouts build() {
         return new Timeouts(shutdownTimeout, shutdownTimeoutUnit);
     }
+
+    private TimeoutsBuilder() {
+        // Construct via newBuilder() factory method.
+    }
 }

--- a/src/test/java/com/eventstore/dbclient/TestTimeoutsBuilder.java
+++ b/src/test/java/com/eventstore/dbclient/TestTimeoutsBuilder.java
@@ -1,0 +1,21 @@
+package com.eventstore.dbclient;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestTimeoutsBuilder {
+    @Test
+    public void testTimeoutsBuilder() {
+        // Note these are NOT reasonable timeout values and are simply used
+        // to test that the builder will construct.
+        Timeouts timeouts = TimeoutsBuilder.newBuilder()
+                .withShutdownTimeout(10, TimeUnit.HOURS)
+                .build();
+
+        assertEquals(10, timeouts.shutdownTimeout);
+        assertEquals(TimeUnit.HOURS, timeouts.shutdownTimeoutUnit);
+    }
+}


### PR DESCRIPTION
This commit adds a test to ensure that the timeouts specified in a `TimeoutsBuilder` are correctly propagated to the `Timeouts` object it builds.

As part of this, we also add a private default constructor for `TimeoutsBuilder` to encourage use of the `newBuilder()` method.