### PR TITLE
Add subscribeToStream support

### DIFF
--- a/src/main/java/com/eventstore/dbclient/Subscription.java
+++ b/src/main/java/com/eventstore/dbclient/Subscription.java
@@ -1,0 +1,22 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.streams.StreamsOuterClass;
+import io.grpc.stub.ClientCallStreamObserver;
+
+public class Subscription {
+    private final ClientCallStreamObserver<StreamsOuterClass.ReadReq> _requestStream;
+    private final String _subscriptionId;
+
+    Subscription(ClientCallStreamObserver<StreamsOuterClass.ReadReq> requestStream, String subscriptionId) {
+        this._requestStream = requestStream;
+        this._subscriptionId = subscriptionId;
+    }
+
+    public String getSubscriptionId() {
+        return _subscriptionId;
+    }
+
+    public void stop() {
+        this._requestStream.cancel("user-initiated", null);
+    }
+}

--- a/src/main/java/com/eventstore/dbclient/SubscriptionListener.java
+++ b/src/main/java/com/eventstore/dbclient/SubscriptionListener.java
@@ -1,0 +1,12 @@
+package com.eventstore.dbclient;
+
+public abstract class SubscriptionListener {
+    void onEvent(Subscription subscription, ResolvedEvent event) {
+    }
+
+    void onError(Subscription subscription, Throwable throwable) {
+    }
+
+    void onCancelled(Subscription subscription) {
+    }
+}

--- a/src/main/java/com/eventstore/dbclient/Timeouts.java
+++ b/src/main/java/com/eventstore/dbclient/Timeouts.java
@@ -6,10 +6,18 @@ public class Timeouts {
     final long shutdownTimeout;
     final TimeUnit shutdownTimeoutUnit;
 
-    public static final Timeouts DEFAULT = new Timeouts(1, TimeUnit.SECONDS);
+    final long subscriptionTimeout;
+    final TimeUnit subscriptionTimeoutUnit;
 
-    Timeouts(final long shutdownTimeout, final TimeUnit shutdownTimeoutUnit) {
+    public static final Timeouts DEFAULT = new Timeouts(
+            5, TimeUnit.SECONDS,
+            5, TimeUnit.SECONDS);
+
+    Timeouts(final long shutdownTimeout, final TimeUnit shutdownTimeoutUnit,
+             final long subscriptionTimeout, final TimeUnit subscriptionTimeoutUnit) {
         this.shutdownTimeout = shutdownTimeout;
         this.shutdownTimeoutUnit = shutdownTimeoutUnit;
+        this.subscriptionTimeout = subscriptionTimeout;
+        this.subscriptionTimeoutUnit = subscriptionTimeoutUnit;
     }
 }

--- a/src/main/java/com/eventstore/dbclient/TimeoutsBuilder.java
+++ b/src/main/java/com/eventstore/dbclient/TimeoutsBuilder.java
@@ -6,6 +6,9 @@ public class TimeoutsBuilder {
     long shutdownTimeout;
     TimeUnit shutdownTimeoutUnit;
 
+    long subscriptionTimeout;
+    TimeUnit subscriptionTimeoutUnit;
+
     public static TimeoutsBuilder newBuilder() {
         TimeoutsBuilder builder = new TimeoutsBuilder();
         builder.shutdownTimeout = Timeouts.DEFAULT.shutdownTimeout;
@@ -19,8 +22,14 @@ public class TimeoutsBuilder {
         return this;
     }
 
+    public TimeoutsBuilder withSubscriptionTimeout(final long timeout, final TimeUnit timeoutUnit) {
+        subscriptionTimeout = timeout;
+        subscriptionTimeoutUnit = timeoutUnit;
+        return this;
+    }
+
     public Timeouts build() {
-        return new Timeouts(shutdownTimeout, shutdownTimeoutUnit);
+        return new Timeouts(shutdownTimeout, shutdownTimeoutUnit, subscriptionTimeout, subscriptionTimeoutUnit);
     }
 
     private TimeoutsBuilder() {

--- a/src/test/java/com/eventstore/dbclient/SubscribeToStreamTests.java
+++ b/src/test/java/com/eventstore/dbclient/SubscribeToStreamTests.java
@@ -1,0 +1,163 @@
+package com.eventstore.dbclient;
+
+import org.junit.Rule;
+import org.junit.Test;
+import testcontainers.module.EventStoreStreamsClient;
+import testcontainers.module.EventStoreTestDBContainer;
+
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.*;
+
+public class SubscribeToStreamTests {
+    @Rule
+    public final EventStoreTestDBContainer server = new EventStoreTestDBContainer(false);
+
+    @Rule
+    public final EventStoreStreamsClient client = new EventStoreStreamsClient(server);
+
+    @Test
+    public void testStreamSubscriptionDeliversAllowsCancellationDuringStream() throws InterruptedException, ExecutionException {
+        final CountDownLatch receivedEvents = new CountDownLatch(1000);
+        final CountDownLatch cancellation = new CountDownLatch(1);
+
+        SubscriptionListener listener = new SubscriptionListener() {
+            @Override
+            void onEvent(Subscription subscription, ResolvedEvent event) {
+                receivedEvents.countDown();
+            }
+
+            @Override
+            void onCancelled(Subscription subscription) {
+                cancellation.countDown();
+            }
+
+            @Override
+            void onError(Subscription subscription, Throwable throwable) {
+                fail(throwable.getMessage());
+            }
+        };
+
+        CompletableFuture<Subscription> future = client.instance
+                .subscribeToStream("dataset20M-0", StreamRevision.START, false, listener);
+        Subscription result = future.get();
+
+        receivedEvents.await();
+        result.stop();
+        cancellation.await();
+    }
+
+    @Test
+    public void testStreamSubscriptionDeliversAllEventsInStream() throws InterruptedException, ExecutionException {
+        final CountDownLatch receivedEvents = new CountDownLatch(6000);
+        final CountDownLatch cancellation = new CountDownLatch(1);
+
+        class CountingListener extends SubscriptionListener {
+            public int current = 0;
+
+            @Override
+            void onEvent(Subscription subscription, ResolvedEvent event) {
+                assertEquals(new StreamRevision(current), event.getEvent().getStreamRevision());
+                current += 1;
+                receivedEvents.countDown();
+            }
+
+            @Override
+            void onCancelled(Subscription subscription) {
+                cancellation.countDown();
+            }
+
+            @Override
+            void onError(Subscription subscription, Throwable throwable) {
+                fail(throwable.getMessage());
+            }
+        }
+
+        CountingListener listener = new CountingListener();
+        CompletableFuture<Subscription> future = client.instance
+                .subscribeToStream("dataset20M-0", StreamRevision.START, false, listener);
+        Subscription result = future.get();
+
+        receivedEvents.await();
+        result.stop();
+        cancellation.await();
+    }
+
+    @Test
+    public void testStreamSubscriptionDeliversAllEventsInStreamAndListensForNewEvents() throws Throwable {
+        final CountDownLatch receivedEvents = new CountDownLatch(6000);
+        final CountDownLatch appendedEvents = new CountDownLatch(1);
+        final CountDownLatch cancellation = new CountDownLatch(1);
+
+        // Appended event data
+        final String testStreamName = "dataset20M-0";
+        final String eventType = "TestEvent";
+        final String eventId = "84c8e36c-4e64-11ea-8b59-b7f658acfc9f";
+        final byte[] eventMetaData = new byte[]{0xd, 0xe, 0xa, 0xd};
+        final byte[] eventData = new byte[]{0xb, 0xe, 0xe, 0xf};
+
+        class CountingListener extends SubscriptionListener {
+            public int current = 0;
+
+            @Override
+            void onEvent(Subscription subscription, ResolvedEvent event) {
+                assertEquals(new StreamRevision(current), event.getEvent().getStreamRevision());
+                current += 1;
+
+                if (current <= 6000) {
+                    receivedEvents.countDown();
+                } else {
+                    appendedEvents.countDown();
+
+                    // Assert the event we appended has correct values
+                    RecordedEvent e = event.getEvent();
+                    assertEquals(eventId, e.getEventId().toString());
+                    assertEquals(new StreamRevision(6000), e.getStreamRevision());
+                    assertEquals(testStreamName, e.getStreamId());
+                    assertEquals(eventType, e.getEventType());
+                    assertArrayEquals(eventMetaData, e.getUserMetadata());
+                    assertArrayEquals(eventData, e.getEventData());
+                }
+            }
+
+            @Override
+            void onCancelled(Subscription subscription) {
+                cancellation.countDown();
+            }
+
+            @Override
+            void onError(Subscription subscription, Throwable throwable) {
+                fail(throwable.getMessage());
+            }
+        }
+
+        // Listen to everything already in the stream
+        CountingListener listener = new CountingListener();
+        CompletableFuture<Subscription> subscriptionFuture = client.instance.
+                subscribeToStream(testStreamName, StreamRevision.START, false, listener);
+        Subscription subscription = subscriptionFuture.get();
+        receivedEvents.await();
+
+        // Write a new event
+        ArrayList<ProposedEvent> events = new ArrayList<>();
+        events.add(new ProposedEvent(UUID.fromString(eventId), eventType,
+                "application/octet-stream", eventData, eventMetaData));
+
+        CompletableFuture<WriteResult> writeFuture = client.instance.appendToStream(testStreamName,
+                new StreamRevision(5999), events);
+        WriteResult writeResult = writeFuture.get();
+
+        assertEquals(new StreamRevision(6000), writeResult.getNextExpectedRevision());
+
+        // Assert the event was forwarded to the subscription
+        appendedEvents.await();
+
+        // Clean up subscription
+        subscription.stop();
+        cancellation.await();
+    }
+}

--- a/src/test/java/com/eventstore/dbclient/TestTimeoutsBuilder.java
+++ b/src/test/java/com/eventstore/dbclient/TestTimeoutsBuilder.java
@@ -13,9 +13,13 @@ public class TestTimeoutsBuilder {
         // to test that the builder will construct.
         Timeouts timeouts = TimeoutsBuilder.newBuilder()
                 .withShutdownTimeout(10, TimeUnit.HOURS)
+                .withSubscriptionTimeout(9, TimeUnit.DAYS)
                 .build();
 
         assertEquals(10, timeouts.shutdownTimeout);
         assertEquals(TimeUnit.HOURS, timeouts.shutdownTimeoutUnit);
+
+        assertEquals(9, timeouts.subscriptionTimeout);
+        assertEquals(TimeUnit.DAYS, timeouts.subscriptionTimeoutUnit);
     }
 }


### PR DESCRIPTION
This commit adds support for the `subscribeToStream` operation to the `StreamsClient`. This returns a `CompletableFuture<Subscription>` which completes when the subscription is confirmed by the server. A new timeout - `subscriptionTimeout` - is introduced to cover the period between subscription initiation and confirmation.

Events, errors and cancellation notices are delivered to the supplied instance of `SubscriptionListener` (which itself is abstract and contains default implementations of each handler).

Tests are added for a variety of conditions:

- user-initiated cancellation of a subscription after delivery of some events
- user-initiated cancellation of a subscription after all events in the stream have been delivered
- user-initiated cancellation of a subscription after all events in the stream have been delivered, a new event appended to the stream and delivery to the subscription verified.

Many of the same types and patterns can be used for subscriptions to `$all`, which will follow in a separate pull request.