### PR TITLE
Add subscribeToAll operation to StreamsClient

### DIFF
--- a/src/main/java/com/eventstore/dbclient/Checkpointer.java
+++ b/src/main/java/com/eventstore/dbclient/Checkpointer.java
@@ -1,0 +1,8 @@
+package com.eventstore.dbclient;
+
+import java.util.concurrent.CompletableFuture;
+
+@FunctionalInterface
+public interface Checkpointer {
+    CompletableFuture<Void> onCheckpoint(Subscription subscription, Position position);
+}

--- a/src/main/java/com/eventstore/dbclient/Subscription.java
+++ b/src/main/java/com/eventstore/dbclient/Subscription.java
@@ -6,10 +6,12 @@ import io.grpc.stub.ClientCallStreamObserver;
 public class Subscription {
     private final ClientCallStreamObserver<StreamsOuterClass.ReadReq> _requestStream;
     private final String _subscriptionId;
+    private final Checkpointer _checkpointer;
 
-    Subscription(ClientCallStreamObserver<StreamsOuterClass.ReadReq> requestStream, String subscriptionId) {
+    Subscription(ClientCallStreamObserver<StreamsOuterClass.ReadReq> requestStream, String subscriptionId, Checkpointer checkpointer) {
         this._requestStream = requestStream;
         this._subscriptionId = subscriptionId;
+        this._checkpointer = checkpointer;
     }
 
     public String getSubscriptionId() {
@@ -18,5 +20,9 @@ public class Subscription {
 
     public void stop() {
         this._requestStream.cancel("user-initiated", null);
+    }
+
+    Checkpointer getCheckpointer() {
+        return this._checkpointer;
     }
 }

--- a/src/main/java/com/eventstore/dbclient/SubscriptionFilter.java
+++ b/src/main/java/com/eventstore/dbclient/SubscriptionFilter.java
@@ -1,0 +1,94 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.shared.Shared;
+import com.eventstore.dbclient.proto.streams.StreamsOuterClass;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class SubscriptionFilter {
+    @NotNull
+    private final EventFilter filter;
+
+    private final int checkpointIntervalUnsigned;
+    private final Checkpointer checkpointer;
+
+    public SubscriptionFilter(@NotNull final EventFilter filter) {
+        this.filter = filter;
+        this.checkpointer = null;
+        this.checkpointIntervalUnsigned = 1; // TODO(jen20): Review this default
+    }
+
+    public SubscriptionFilter(@NotNull final EventFilter filter,
+                              final int checkpointIntervalUnsigned,
+                              @NotNull final Checkpointer checkpointer) {
+        this.filter = filter;
+        this.checkpointer = checkpointer;
+        this.checkpointIntervalUnsigned = checkpointIntervalUnsigned;
+    }
+
+    public EventFilter getFilter() {
+        return filter;
+    }
+
+    public int getCheckpointIntervalUnsigned() {
+        return checkpointIntervalUnsigned;
+    }
+
+    public Checkpointer getCheckpointer() {
+        return checkpointer;
+    }
+
+    void addToWireReadReq(StreamsOuterClass.ReadReq.Options.Builder builder) {
+        RegularFilterExpression regex = filter.getRegularFilterExpression();
+        PrefixFilterExpression[] prefixes = filter.getPrefixFilterExpressions();
+        Optional<Integer> maxSearchWindow = filter.getMaxSearchWindow();
+
+        if (regex != null && prefixes != null && prefixes.length != 0) {
+            throw new IllegalArgumentException("Regex and Prefix expressions are mutually exclusive");
+        }
+
+        StreamsOuterClass.ReadReq.Options.FilterOptions.Expression expression = null;
+        if (regex != null) {
+            expression = StreamsOuterClass.ReadReq.Options.FilterOptions.Expression.newBuilder()
+                    .setRegex(regex.toString())
+                    .build();
+        }
+
+        if (prefixes != null && prefixes.length > 0) {
+            StreamsOuterClass.ReadReq.Options.FilterOptions.Expression.Builder expressionB = StreamsOuterClass.ReadReq.Options.FilterOptions.Expression.newBuilder();
+            Stream.of(prefixes)
+                    .map(Object::toString)
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .forEach(expressionB::addPrefix);
+            expression = expressionB.build();
+        }
+
+        if (expression == null) {
+            builder.setNoFilter(Shared.Empty.getDefaultInstance());
+            return;
+        }
+
+        StreamsOuterClass.ReadReq.Options.FilterOptions.Builder optsB = StreamsOuterClass.ReadReq.Options.FilterOptions.newBuilder();
+        if (filter instanceof StreamFilter) {
+            optsB.setStreamName(expression);
+        }
+        if (filter instanceof EventTypeFilter) {
+            optsB.setEventType(expression);
+        }
+
+        if (maxSearchWindow != null && maxSearchWindow.isPresent()) {
+            optsB.setMax(maxSearchWindow.get());
+        } else {
+            optsB.setCount(Shared.Empty.getDefaultInstance());
+        }
+
+        optsB.setCheckpointIntervalMultiplier(this.checkpointIntervalUnsigned);
+
+        builder.setFilter(optsB.build());
+    }
+}
+

--- a/src/test/java/com/eventstore/dbclient/SubscribeToAllTests.java
+++ b/src/test/java/com/eventstore/dbclient/SubscribeToAllTests.java
@@ -1,0 +1,136 @@
+package com.eventstore.dbclient;
+
+import org.junit.Rule;
+import org.junit.Test;
+import testcontainers.module.EventStoreStreamsClient;
+import testcontainers.module.EventStoreTestDBContainer;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+public class SubscribeToAllTests {
+    @Rule
+    public final EventStoreTestDBContainer server = new EventStoreTestDBContainer(false);
+
+    @Rule
+    public final EventStoreStreamsClient client = new EventStoreStreamsClient(server);
+
+    @Test
+    public void testAllSubscriptionDeliversAllowsCancellationDuringStream() throws InterruptedException, ExecutionException {
+        final CountDownLatch receivedEvents = new CountDownLatch(1000);
+        final CountDownLatch cancellation = new CountDownLatch(1);
+
+        SubscriptionListener listener = new SubscriptionListener() {
+            @Override
+            void onEvent(Subscription subscription, ResolvedEvent event) {
+                receivedEvents.countDown();
+            }
+
+            @Override
+            void onCancelled(Subscription subscription) {
+                cancellation.countDown();
+            }
+
+            @Override
+            void onError(Subscription subscription, Throwable throwable) {
+                fail(throwable.getMessage());
+            }
+        };
+
+        CompletableFuture<Subscription> future = client.instance.subscribeToAll(Position.START, false, listener);
+        Subscription result = future.get();
+
+        receivedEvents.await();
+        result.stop();
+        cancellation.await();
+    }
+
+    @Test
+    public void testAllSubscriptionWithFilterDeliversCorrectEvents() throws InterruptedException, ExecutionException {
+        final Position[] expectedPositions = new Position[]{
+                new Position(137783, 108819),
+                new Position(167653, 138689),
+                new Position(197523, 168559),
+                new Position(227393, 198429),
+                new Position(257263, 228299),
+                new Position(287133, 258169),
+                new Position(317003, 288039),
+                new Position(346873, 317909),
+                new Position(376743, 347779),
+                new Position(406613, 377649),
+                new Position(12932074, 12903110),
+                new Position(12961944, 12932980),
+                new Position(12991814, 12962850),
+                new Position(13021684, 12992720),
+                new Position(13051554, 13022590),
+                new Position(13081424, 13052460),
+                new Position(13111294, 13082330),
+                new Position(13141164, 13112200),
+                new Position(13171034, 13142070),
+                new Position(13200904, 13171940),
+                new Position(17932093, 17903129),
+                new Position(17961963, 17932999),
+                new Position(17991833, 17962869),
+                new Position(18021703, 17992739),
+                new Position(18051573, 18022609),
+                new Position(18081443, 18052479),
+                new Position(18111313, 18082349),
+                new Position(18141183, 18112219),
+                new Position(18171053, 18142089),
+                new Position(18200923, 18171959),
+        };
+        final long[] expectedStreamVersions = new long[]{
+                194, 394, 594, 794, 994, 1194, 1394, 1594, 1794, 1994, 2194, 2394, 2594, 2794, 2994, 3194, 3394, 3594,
+                3794, 3994, 4194, 4394, 4594, 4794, 4994, 5194, 5394, 5594, 5794, 5994,
+        };
+        assertEquals(expectedPositions.length, expectedStreamVersions.length);
+
+        final CountDownLatch receivedEvents = new CountDownLatch(expectedStreamVersions.length);
+        final CountDownLatch cancellation = new CountDownLatch(1);
+
+        SubscriptionListener listener = new SubscriptionListener() {
+            int current = 0;
+
+            @Override
+            void onEvent(Subscription subscription, ResolvedEvent event) {
+                RecordedEvent record = event.getEvent();
+
+                assertEquals(new StreamRevision(expectedStreamVersions[current]), record.getStreamRevision());
+                assertEquals(expectedPositions[current], record.getPosition());
+
+                receivedEvents.countDown();
+                current++;
+            }
+
+            @Override
+            void onCancelled(Subscription subscription) {
+                cancellation.countDown();
+            }
+
+            @Override
+            void onError(Subscription subscription, Throwable throwable) {
+                fail(throwable.getMessage());
+            }
+        };
+
+        CompletableFuture<Subscription> future = client.instance.subscribeToAll(Position.START,
+                false, listener,
+                new SubscriptionFilter(
+                        new EventTypeFilter(Optional.empty(),
+                                new RegularFilterExpression(Pattern.compile("^eventType-194$")))));
+        Subscription result = future.get();
+
+        assertNotNull(result.getSubscriptionId());
+        assertNotEquals("", result.getSubscriptionId());
+
+        receivedEvents.await();
+        result.stop();
+        cancellation.await();
+    }
+}
+


### PR DESCRIPTION
This commit adds the subscribeToAll operation to the `StreamsClient` class. In order to correctly support the protocol, a `SubscriptionFilter` type is introduced which allows specification of a `Checkpointer` for recording checkpoints where events do not match the filter.

As part of this, we rework adding the filter to an outbound `ReadReq` making better use of object oriented programming rather than static methods.

Testing is currently somewhat rudimentary but was sufficient to confirm basic operation as well as find some bugs:

- we test 1000 events before cancelling the read from `$all`
- we perform a filtered read on a stream, comparing the positions and event types with the expected values from the known dataset.