### PR TITLE
Add SubscriptionFilterBuilder class

### DIFF
--- a/src/main/java/com/eventstore/dbclient/SubscriptionFilter.java
+++ b/src/main/java/com/eventstore/dbclient/SubscriptionFilter.java
@@ -15,6 +15,10 @@ public class SubscriptionFilter {
     private final int checkpointIntervalUnsigned;
     private final Checkpointer checkpointer;
 
+    public static SubscriptionFilterBuilder newBuilder() {
+        return new SubscriptionFilterBuilder();
+    }
+
     public SubscriptionFilter(@NotNull final EventFilter filter) {
         this.filter = filter;
         this.checkpointer = null;
@@ -29,15 +33,7 @@ public class SubscriptionFilter {
         this.checkpointIntervalUnsigned = checkpointIntervalUnsigned;
     }
 
-    public EventFilter getFilter() {
-        return filter;
-    }
-
-    public int getCheckpointIntervalUnsigned() {
-        return checkpointIntervalUnsigned;
-    }
-
-    public Checkpointer getCheckpointer() {
+    Checkpointer getCheckpointer() {
         return checkpointer;
     }
 

--- a/src/main/java/com/eventstore/dbclient/SubscriptionFilterBuilder.java
+++ b/src/main/java/com/eventstore/dbclient/SubscriptionFilterBuilder.java
@@ -1,0 +1,117 @@
+package com.eventstore.dbclient;
+
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class SubscriptionFilterBuilder {
+    private int _checkpointIntervalUnsigned = 1;
+    private Checkpointer _checkpointer = null;
+    private FilterType _filterType = null;
+    private Optional<Integer> _maxWindow;
+    private RegularFilterExpression _regular = null;
+    private PrefixFilterExpression _prefix = null;
+
+    private enum FilterType {
+        STREAM,
+        EVENT_TYPE;
+    }
+
+    public SubscriptionFilterBuilder() {
+    }
+
+    public SubscriptionFilterBuilder withMaxWindow(int maxWindow) {
+        _maxWindow = Optional.of(maxWindow);
+        return this;
+    }
+
+    public SubscriptionFilterBuilder withStreamNameRegularExpression(@NotNull String pattern) {
+        if (_filterType != null) {
+            throw new IllegalStateException(String.format("Filter type is already set to %s", _filterType.name()));
+        }
+
+        _filterType = FilterType.STREAM;
+        _regular = new RegularFilterExpression(Pattern.compile(pattern));
+
+        return this;
+    }
+
+    public SubscriptionFilterBuilder withStreamNamePrefix(@NotNull String prefix) {
+        if (_filterType != null) {
+            throw new IllegalStateException(String.format("Filter type is already set to %s", _filterType.name()));
+        }
+
+        _filterType = FilterType.STREAM;
+        _prefix = new PrefixFilterExpression(prefix);
+
+        return this;
+    }
+
+    public SubscriptionFilterBuilder withEventTypeRegularExpression(@NotNull String pattern) {
+        if (_filterType != null) {
+            throw new IllegalStateException(String.format("Filter type is already set to %s", _filterType.name()));
+        }
+
+        _filterType = FilterType.EVENT_TYPE;
+        _regular = new RegularFilterExpression(Pattern.compile(pattern));
+
+        return this;
+    }
+
+    public SubscriptionFilterBuilder withEventTypePrefix(@NotNull String prefix) {
+        if (_filterType != null) {
+            throw new IllegalStateException(String.format("Filter type is already set to %s", _filterType.name()));
+        }
+
+        _filterType = FilterType.EVENT_TYPE;
+        _prefix = new PrefixFilterExpression(prefix);
+
+        return this;
+    }
+
+    public SubscriptionFilterBuilder withCheckpointer(@NotNull Checkpointer checkpointer, int intervalMultiplierUnsigned) {
+        this._checkpointIntervalUnsigned = intervalMultiplierUnsigned;
+        this._checkpointer = checkpointer;
+
+        return this;
+    }
+
+    public SubscriptionFilterBuilder withCheckpointer(@NotNull Checkpointer checkpointer) {
+        return this.withCheckpointer(checkpointer, 1);
+    }
+
+    public SubscriptionFilter build() {
+        if (_filterType == null) {
+            throw new IllegalStateException("No filter type is specified");
+        }
+
+        switch (this._filterType) {
+            case STREAM:
+                StreamFilter s;
+                if (_regular != null) {
+                    s = new StreamFilter(this._maxWindow, _regular);
+                } else if (_prefix != null) {
+                    s = new StreamFilter(this._maxWindow, _prefix);
+                } else {
+                    throw new IllegalStateException("Neither prefix or regular expression stream filter is configured");
+                }
+
+                return new SubscriptionFilter(s, this._checkpointIntervalUnsigned, this._checkpointer);
+
+            case EVENT_TYPE:
+                EventTypeFilter et;
+                if (_regular != null) {
+                    et = new EventTypeFilter(this._maxWindow, _regular);
+                } else if (_prefix != null) {
+                    et = new EventTypeFilter(this._maxWindow, _prefix);
+                } else {
+                    throw new IllegalStateException("Neither prefix or regular expression event type filter is configured");
+                }
+
+                return new SubscriptionFilter(et, this._checkpointIntervalUnsigned, this._checkpointer);
+
+            default:
+                throw new IllegalStateException(String.format("Unhandled filter type variant: %s", this._filterType.name()));
+        }
+    }
+}

--- a/src/test/java/com/eventstore/dbclient/SubscribeToAllTests.java
+++ b/src/test/java/com/eventstore/dbclient/SubscribeToAllTests.java
@@ -5,11 +5,9 @@ import org.junit.Test;
 import testcontainers.module.EventStoreStreamsClient;
 import testcontainers.module.EventStoreTestDBContainer;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
 
@@ -118,11 +116,11 @@ public class SubscribeToAllTests {
             }
         };
 
-        CompletableFuture<Subscription> future = client.instance.subscribeToAll(Position.START,
-                false, listener,
-                new SubscriptionFilter(
-                        new EventTypeFilter(Optional.empty(),
-                                new RegularFilterExpression(Pattern.compile("^eventType-194$")))));
+        SubscriptionFilter filter = SubscriptionFilter.newBuilder()
+                .withEventTypeRegularExpression("^eventType-194$")
+                .build();
+
+        CompletableFuture<Subscription> future = client.instance.subscribeToAll(Position.START, false, listener, filter);
         Subscription result = future.get();
 
         assertNotNull(result.getSubscriptionId());


### PR DESCRIPTION
Building `SubscriptionFilter` instances is somewhat involved - it's necessary to construct either a `StreamFilter` or `EventTypeFilter` with the appropriate Prefix or Regular expressions, and configure checkpoints and windowing.

This commit adds a `SubscriptionFilterBuilder` to reduce the amount of boilerplate needed for this.

For example, this construction:

```
SubscriptionFilter filter = new SubscriptionFilter(
  new EventTypeFilter(Optional.empty(),
    new RegularFilterExpression(Pattern.compile("^eventType-194$"))));
```

Becomes this builder instantiation:

```
SubscriptionFilter filter = SubscriptionFilter.newBuilder()
  .withEventTypeRegularExpression("^eventType-194$")
  .build();
```

The difference is more acute when a `Checkpointer` and optional non-default interval is specified.

The previous mechanism is still available (and used internally by the builder) for if unusual options or a more manual construction system is needed.

Fixes #11.