### PR TITLE
Add IntelliJ IDEA plugin to Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 plugins {
     id "java"
     id "com.google.protobuf" version "0.8.12"
+    id "idea"
 }
 
 group 'com.eventstore'


### PR DESCRIPTION
This adds a Gradle task named `idea` which generates IntelliJ IDEA `ipr` project files. Note that the project files themselves should be gitignored, and are not checked in - the Gradle build is the source of truth for project structure.