### PR TITLE
Run 'gradle publish' on trunk pushes

### DIFF
--- a/.github/workflows/trunk-push.yml
+++ b/.github/workflows/trunk-push.yml
@@ -40,3 +40,8 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: test
+
+      - name: Publish GitHub Packages
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: publish


### PR DESCRIPTION
#23 put in place the infrastructure to publish packages and separated CI, this completes that work by actually publishing packages for trunk branch pushes.