### PR TITLE
Fix SNAPSHOT publishing to GitHub Packages

### DIFF
--- a/db-client-java/build.gradle
+++ b/db-client-java/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java-library'
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/spotbugs.gradle')
 apply from: rootProject.file('gradle/updateProtos.gradle')
+apply from: rootProject.file('gradle/publishing.gradle')
 
 dependencies {
 	implementation "javax.annotation:javax.annotation-api:${annotationApiVersion}"

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'maven-publish'
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/EventStore/EventStoreDB-Client-Java")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+    publications {
+        Snapshot(MavenPublication) {
+            from(components.java)
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new Gradle build file which publishes snapshot releases to GitHub Packages.

Fixes #30.