### PR TITLE
Added limited projection functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,44 @@ public class Main {
 }
 ```
 
+## Projections
+
+This client currently supports creating and getting the result of a continuous projection.
+
+Create a projection:
+```java
+client.projections()
+    .createContinuous(PROJECTION_NAME, PROJECTION_JS, false)
+    .execute()
+    .get();
+```
+
+Define a class in which to deserialize the result:
+```java
+public class CountResult {
+
+    private int count;
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(final int count) {
+        this.count = count;
+    }
+}
+```
+
+Get the result:
+```java
+CountResult result = client.projections()
+    .getResult(PROJECTION_NAME, CountResult.class)
+    .execute()
+    .get();
+```
+
+For further details please see [the projection management tests](src/test/java/com/eventstore/dbclient/ProjectionManagementTests.java).
+
 ## Support
 
 Information on support can be found on our website: [Event Store Support][support]

--- a/db-client-java/build.gradle
+++ b/db-client-java/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation "javax.validation:validation-api:${validationApiVersion}"
 
     implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
+    implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
     implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/db-client-java/src/main/java/com/eventstore/dbclient/Client.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/Client.java
@@ -63,4 +63,8 @@ public class Client {
     public void shutdown() throws InterruptedException {
         this.client.shutdown();
     }
+
+    public Projections projections() {
+        return new Projections(this.client, this.credentials);
+    }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/CreatePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/CreatePersistentSubscription.java
@@ -86,7 +86,7 @@ public class CreatePersistentSubscription {
                     .setOptions(builder)
                     .build();
 
-            client.create(req, GrpcUtils.convertSingleResponse(result, Function.identity()));
+            client.create(req, GrpcUtils.convertSingleResponse(result));
 
             return result;
         });

--- a/db-client-java/src/main/java/com/eventstore/dbclient/CreateProjection.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/CreateProjection.java
@@ -1,0 +1,91 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.projections.Projectionmanagement;
+import com.eventstore.dbclient.proto.projections.ProjectionsGrpc;
+import com.eventstore.dbclient.proto.shared.Shared;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+public class CreateProjection {
+
+    private final GrpcClient client;
+    private final boolean continuous;
+    private final String projectionName;
+    private final String query;
+    private final boolean trackEmittedStreams;
+    private final ConnectionMetadata metadata;
+
+    private CreateProjection(final GrpcClient client, final UserCredentials credentials, final boolean continuous,
+                            final String projectionName, final String query, final boolean trackEmittedStreams) {
+
+        this.client = client;
+        this.continuous = continuous;
+        this.projectionName = projectionName;
+        this.query = query;
+        this.trackEmittedStreams = trackEmittedStreams;
+
+        this.metadata = new ConnectionMetadata();
+
+        if (credentials != null) {
+            this.metadata.authenticated(credentials);
+        }
+    }
+
+    static CreateProjection forContinuous(final GrpcClient client, final UserCredentials credentials,
+                                                 final String projectionName, final String query,
+                                                 final boolean trackEmittedStreams) {
+
+        return new CreateProjection(client, credentials, true, projectionName, query, trackEmittedStreams);
+    }
+
+    public CreateProjection authenticated(UserCredentials credentials) {
+        this.metadata.authenticated(credentials);
+        return this;
+    }
+
+    public CompletableFuture execute() {
+
+        return this.client.run(channel -> {
+
+            Projectionmanagement.CreateReq.Options.Builder optionsBuilder =
+                    Projectionmanagement.CreateReq.Options.newBuilder()
+                        .setQuery(query);
+
+            setContinuousOrOneTime(optionsBuilder);
+
+            Projectionmanagement.CreateReq request = Projectionmanagement.CreateReq.newBuilder()
+                    .setOptions(optionsBuilder)
+                    .build();
+
+            Metadata headers = this.metadata.build();
+
+            ProjectionsGrpc.ProjectionsStub client = MetadataUtils.attachHeaders(ProjectionsGrpc.newStub(channel), headers);
+
+            CompletableFuture<Projectionmanagement.CreateResp> result = new CompletableFuture<>();
+
+            client.create(request, GrpcUtils.convertSingleResponse(result));
+
+            return result;
+        });
+    }
+
+    private void setContinuousOrOneTime(final Projectionmanagement.CreateReq.Options.Builder optionsBuilder) {
+
+        if(continuous) {
+
+            Projectionmanagement.CreateReq.Options.Continuous.Builder continuousBuilder =
+                    Projectionmanagement.CreateReq.Options.Continuous.newBuilder();
+
+            continuousBuilder.setTrackEmittedStreams(trackEmittedStreams);
+            continuousBuilder.setName(projectionName);
+
+            optionsBuilder.setContinuous(continuousBuilder);
+
+        } else {
+
+            optionsBuilder.setOneTime(Shared.Empty.newBuilder());
+        }
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/DeletePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/DeletePersistentSubscription.java
@@ -52,7 +52,7 @@ public class DeletePersistentSubscription {
                     .setOptions(options)
                     .build();
 
-            client.delete(req, GrpcUtils.convertSingleResponse(result, Function.identity()));
+            client.delete(req, GrpcUtils.convertSingleResponse(result));
 
             return result;
         });

--- a/db-client-java/src/main/java/com/eventstore/dbclient/GetProjectionResult.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/GetProjectionResult.java
@@ -1,0 +1,90 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.projections.Projectionmanagement;
+import com.eventstore.dbclient.proto.projections.ProjectionsGrpc;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.protobuf.util.JsonFormat;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+public class GetProjectionResult<TResult> {
+
+    private final GrpcClient client;
+    private final String projectionName;
+
+    private final ConnectionMetadata metadata;
+
+    private ThrowingBiFunction<JsonMapper, String, TResult, JsonProcessingException> deserializationStrategy;
+
+    GetProjectionResult(final GrpcClient client, final UserCredentials credentials,
+                               final String projectionName, Class<TResult> resultType) {
+
+        this(client, credentials, projectionName);
+        deserializationStrategy = ((jsonMapper, json) -> jsonMapper.readValue(json, resultType));
+    }
+
+    GetProjectionResult(final GrpcClient client, final UserCredentials credentials,
+                               final String projectionName,
+                               Function<TypeFactory, JavaType> javaTypeFunction) {
+
+        this(client, credentials, projectionName);
+        deserializationStrategy = ((jsonMapper, json)
+                -> jsonMapper.readValue(json, javaTypeFunction.apply(jsonMapper.getTypeFactory())));
+    }
+
+    private GetProjectionResult(final GrpcClient client, final UserCredentials credentials,
+                               final String projectionName) {
+
+        this.client = client;
+        this.projectionName = projectionName;
+
+        this.metadata = new ConnectionMetadata();
+
+        if (credentials != null) {
+            this.metadata.authenticated(credentials);
+        }
+    }
+
+
+    public GetProjectionResult authenticated(UserCredentials credentials) {
+        this.metadata.authenticated(credentials);
+        return this;
+    }
+
+    public CompletableFuture<TResult> execute() {
+
+        return this.client.run(channel -> {
+
+            Projectionmanagement.ResultReq.Options.Builder optionsBuilder =
+                    Projectionmanagement.ResultReq.Options.newBuilder()
+                            .setName(projectionName);
+
+
+            Projectionmanagement.ResultReq request = Projectionmanagement.ResultReq.newBuilder()
+                    .setOptions(optionsBuilder)
+                    .build();
+
+            Metadata headers = this.metadata.build();
+
+            ProjectionsGrpc.ProjectionsStub client = MetadataUtils.attachHeaders(ProjectionsGrpc.newStub(channel), headers);
+
+            CompletableFuture<TResult> result = new CompletableFuture<>();
+
+            ThrowingFunction<Projectionmanagement.ResultResp, TResult, Exception> converter = source -> {
+
+                String json = JsonFormat.printer().print(source.getResult());
+                return deserializationStrategy.apply(new JsonMapper(), json);
+            };
+
+            client.result(request, GrpcUtils.convertSingleResponse(result, converter));
+
+            return result;
+        });
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/GrpcUtils.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/GrpcUtils.java
@@ -12,8 +12,17 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 public final class GrpcUtils {
-    static public <ReqT, RespT, TargetT> ClientResponseObserver<ReqT, RespT> convertSingleResponse(
-            CompletableFuture<TargetT> dest, Function<RespT, TargetT> converter) {
+
+
+    static public <ReqT, RespT> ClientResponseObserver<ReqT, RespT> convertSingleResponse(
+            CompletableFuture<RespT> dest) {
+
+        return convertSingleResponse(dest, x -> x);
+    }
+
+    static public <ReqT, RespT, TargetT, ExceptionT extends Throwable> ClientResponseObserver<ReqT, RespT> convertSingleResponse(
+            CompletableFuture<TargetT> dest, ThrowingFunction<RespT, TargetT, ExceptionT> converter) {
+
         return new ClientResponseObserver<ReqT, RespT>() {
             @Override
             public void beforeStart(ClientCallStreamObserver<ReqT> requestStream) {

--- a/db-client-java/src/main/java/com/eventstore/dbclient/Projections.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/Projections.java
@@ -1,0 +1,35 @@
+package com.eventstore.dbclient;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.util.function.Function;
+
+public class Projections {
+
+    private GrpcClient client;
+    private UserCredentials credentials;
+
+    public Projections(final GrpcClient client, final UserCredentials credentials) {
+
+        this.client = client;
+        this.credentials = credentials;
+    }
+
+    public CreateProjection createContinuous(final String projectionName, final String query, final boolean trackEmittedStreams) {
+
+        return CreateProjection.forContinuous(this.client, this.credentials, projectionName, query, trackEmittedStreams);
+    }
+
+    public <TResult> GetProjectionResult<TResult> getResult(final String projectionName, Class<TResult> type) {
+
+        return new GetProjectionResult<>(this.client, this.credentials, projectionName, type);
+    }
+
+    public <TResult> GetProjectionResult<TResult> getResult(final String projectionName,
+                                                            Function<TypeFactory, JavaType> javaTypeFunction) {
+
+        return new GetProjectionResult<>(this.client, this.credentials, projectionName, javaTypeFunction);
+    }
+
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ThrowingBiFunction.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ThrowingBiFunction.java
@@ -1,0 +1,7 @@
+package com.eventstore.dbclient;
+
+@FunctionalInterface
+interface ThrowingBiFunction<TFirst, TSecond, TResult, TException extends Throwable> {
+
+    TResult apply(TFirst first, TSecond second) throws TException;
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ThrowingFunction.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ThrowingFunction.java
@@ -1,0 +1,7 @@
+package com.eventstore.dbclient;
+
+@FunctionalInterface
+interface ThrowingFunction<TInput, TResult, TException extends Throwable> {
+
+    TResult apply(TInput first) throws TException;
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/UpdatePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/UpdatePersistentSubscription.java
@@ -86,7 +86,7 @@ public class UpdatePersistentSubscription {
                     .setOptions(builder)
                     .build();
 
-            client.update(req, GrpcUtils.convertSingleResponse(result, Function.identity()));
+            client.update(req, GrpcUtils.convertSingleResponse(result));
 
             return result;
         });

--- a/db-client-java/src/main/proto/projectionmanagement.proto
+++ b/db-client-java/src/main/proto/projectionmanagement.proto
@@ -1,0 +1,174 @@
+syntax = "proto3";
+package event_store.client.projections;
+option java_package = "com.eventstore.dbclient.proto.projections";
+
+import "google/protobuf/struct.proto";
+import "shared.proto";
+
+service Projections {
+	rpc Create (CreateReq) returns (CreateResp);
+	rpc Update (UpdateReq) returns (UpdateResp);
+	rpc Delete (DeleteReq) returns (DeleteResp);
+	rpc Statistics (StatisticsReq) returns (stream StatisticsResp);
+	rpc Disable (DisableReq) returns (DisableResp);
+	rpc Enable (EnableReq) returns (EnableResp);
+	rpc Reset (ResetReq) returns (ResetResp);
+	rpc State (StateReq) returns (StateResp);
+	rpc Result (ResultReq) returns (ResultResp);
+	rpc RestartSubsystem (event_store.client.shared.Empty) returns (event_store.client.shared.Empty);
+}
+
+message CreateReq {
+	Options options = 1;
+
+	message Options {
+		oneof mode {
+			event_store.client.shared.Empty one_time = 1;
+			Transient transient = 2;
+			Continuous continuous = 3;
+		}
+		string query = 4;
+
+		message Transient {
+			string name = 1;
+		}
+		message Continuous {
+			string name = 1;
+			bool track_emitted_streams = 2;
+		}
+	}
+}
+
+message CreateResp {
+}
+
+message UpdateReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+		string query = 2;
+		oneof emit_option {
+			bool emit_enabled = 3;
+			event_store.client.shared.Empty no_emit_options = 4;
+		}
+	}
+}
+
+message UpdateResp {
+}
+
+message DeleteReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+		bool delete_emitted_streams = 2;
+		bool delete_state_stream = 3;
+		bool delete_checkpoint_stream = 4;
+	}
+}
+
+message DeleteResp {
+}
+
+message StatisticsReq {
+	Options options = 1;
+	message Options {
+		oneof mode {
+			string name = 1;
+			event_store.client.shared.Empty all = 2;
+			event_store.client.shared.Empty transient = 3;
+			event_store.client.shared.Empty continuous = 4;
+			event_store.client.shared.Empty one_time = 5;
+		}
+	}
+}
+
+message StatisticsResp {
+	Details details = 1;
+
+	message Details {
+		int64 coreProcessingTime = 1;
+		int64 version = 2;
+		int64 epoch = 3;
+		string effectiveName = 4;
+		int32 writesInProgress = 5;
+		int32 readsInProgress = 6;
+		int32 partitionsCached = 7;
+		string status = 8;
+		string stateReason = 9;
+		string name = 10;
+		string mode = 11;
+		string position = 12;
+		float progress = 13;
+		string lastCheckpoint = 14;
+		int64 eventsProcessedAfterRestart = 15;
+		string checkpointStatus = 16;
+		int64 bufferedEvents = 17;
+		int32 writePendingEventsBeforeCheckpoint = 18;
+		int32 writePendingEventsAfterCheckpoint = 19;
+	}
+}
+
+message StateReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+		string partition = 2;
+	}
+}
+
+message StateResp {
+	google.protobuf.Value state = 1;
+}
+
+message ResultReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+		string partition = 2;
+	}
+}
+
+message ResultResp {
+	google.protobuf.Value result = 1;
+}
+
+message ResetReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+		bool write_checkpoint = 2;
+	}
+}
+
+message ResetResp {
+}
+
+
+message EnableReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+	}
+}
+
+message EnableResp {
+}
+
+message DisableReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+		bool write_checkpoint = 2;
+	}
+}
+
+message DisableResp {
+}

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ProjectionManagementTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ProjectionManagementTests.java
@@ -1,0 +1,140 @@
+package com.eventstore.dbclient;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import testcontainers.module.EventStoreTestDBContainer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+public class ProjectionManagementTests {
+
+    @Rule
+    public final EventStoreTestDBContainer server = new EventStoreTestDBContainer(false, true);
+
+    private static final String PROJECTION_NAME = "projection";
+
+    private static final String UNKNOWN_KEYNAMES_PROJECTION_FILENAME = "state-with-unknown-keynames.js";
+    private static final String COUNT_EVENTS_PROJECTION_FILENAME = "count-events-projection.js";
+
+    private static final int EXPECTED_EVENT_COUNT = 2000;
+
+
+    private static String COUNT_EVENTS_PROJECTION;
+    private static String UNKNOWN_KEYNAMES_PROJECTION;
+
+    @BeforeClass
+    public static void loadProjectionJs() throws IOException {
+
+        COUNT_EVENTS_PROJECTION = loadResourceAsString(COUNT_EVENTS_PROJECTION_FILENAME);
+        UNKNOWN_KEYNAMES_PROJECTION = loadResourceAsString(UNKNOWN_KEYNAMES_PROJECTION_FILENAME);
+    }
+
+    private static String loadResourceAsString(String fileName) throws IOException {
+
+        try(BufferedReader reader = new BufferedReader(new InputStreamReader(ProjectionManagementTests.class.getClassLoader()
+                .getResourceAsStream(fileName)))) {
+
+            return reader.lines().collect(Collectors.joining("\n"));
+        }
+    }
+
+    @Test
+    public void testCreateAndGetContinuousProjection() throws ExecutionException, InterruptedException {
+
+        createProjection(COUNT_EVENTS_PROJECTION);
+
+        CountResult result = getResultOfCountingProjection();
+
+        assertCountingProjectionResultAsExpected(result);
+    }
+
+    @Test
+    public void testDeserializingBasedOnJavaType() throws ExecutionException, InterruptedException {
+
+        createProjection(UNKNOWN_KEYNAMES_PROJECTION);
+
+        Map<String, Item> result = getResultOfUnknownKeyNamesProjection();
+
+        assertDeserializedIntoMap(result);
+    }
+
+    private void assertDeserializedIntoMap(final Map<String, Item> result) {
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.entrySet().isEmpty());
+        Map.Entry<String, Item> firstEntry = result.entrySet().stream().findFirst().get();
+        Assert.assertNotNull(firstEntry.getKey());
+        Item firstItem = firstEntry.getValue();
+        Assert.assertNotNull(firstItem);
+        Assert.assertNotNull(firstItem.getTimeArrivedMillis());
+    }
+
+    private void createProjection(
+            final String projectionWithUnknownKeynames) throws InterruptedException, ExecutionException {
+
+        server.getProjectionManagementAPI()
+                .createContinuous(PROJECTION_NAME, projectionWithUnknownKeynames, false)
+                .execute()
+                .get();
+    }
+
+    private CountResult getResultOfCountingProjection() throws InterruptedException, ExecutionException {
+
+        return server.getProjectionManagementAPI()
+                .getResult(PROJECTION_NAME, CountResult.class)
+                .execute()
+                .get();
+    }
+
+    private Map<String, Item> getResultOfUnknownKeyNamesProjection() throws ExecutionException, InterruptedException {
+
+        return server.getProjectionManagementAPI()
+                .<Map<String, Item>>getResult(PROJECTION_NAME, factory -> factory.constructMapType(HashMap.class, String.class, Item.class))
+                .execute()
+                .get();
+    }
+
+    private void assertCountingProjectionResultAsExpected(final CountResult result) {
+
+        Assert.assertNotNull(result);
+        //The projection may not have completed so may not yet equal EXPECTED_EVENT_COUNT
+        //that's okay we're not testing the server, just that the projection has been
+        //created correctly and is running
+        Assert.assertTrue(result.getCount() > 0);
+        Assert.assertTrue(result.getCount() <= EXPECTED_EVENT_COUNT);
+    }
+
+    public static class CountResult {
+
+        private int count;
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(final int count) {
+            this.count = count;
+        }
+    }
+
+    public static class Item {
+
+        private Long timeArrivedMillis;
+
+        public Long getTimeArrivedMillis() {
+            return timeArrivedMillis;
+        }
+
+        public void setTimeArrivedMillis(final Long timeArrivedMillis) {
+            this.timeArrivedMillis = timeArrivedMillis;
+        }
+    }
+}

--- a/db-client-java/src/test/java/testcontainers/module/EventStoreTestDBContainer.java
+++ b/db-client-java/src/test/java/testcontainers/module/EventStoreTestDBContainer.java
@@ -31,10 +31,22 @@ public class EventStoreTestDBContainer extends GenericContainer<EventStoreTestDB
         this(IMAGE + ":" + IMAGE_TAG, emptyDatabase);
     }
 
+    public EventStoreTestDBContainer(boolean emptyDatabase, boolean runProjections) {
+        this(IMAGE + ":" + IMAGE_TAG, emptyDatabase, runProjections);
+    }
+
     public EventStoreTestDBContainer(String image, boolean emptyDatabase) {
+        this(image, emptyDatabase, false);
+    }
+
+    public EventStoreTestDBContainer(String image, boolean emptyDatabase, boolean runProjections) {
         super(image);
 
         addExposedPorts(1113, 2113);
+
+        if(runProjections) {
+            withEnv("EVENTSTORE_RUN_PROJECTIONS", "ALL");
+        }
 
         withEnv("EVENTSTORE_INSECURE", "true");
         if (!emptyDatabase) {
@@ -60,5 +72,10 @@ public class EventStoreTestDBContainer extends GenericContainer<EventStoreTestDB
 
     public PersistentSubscriptions getPersistentSubscriptionsAPI() {
         return getClient().persistentSubscriptions();
+    }
+
+    public Projections getProjectionManagementAPI() {
+
+        return getClient().projections();
     }
 }

--- a/db-client-java/src/test/resources/count-events-projection.js
+++ b/db-client-java/src/test/resources/count-events-projection.js
@@ -1,0 +1,11 @@
+fromStream('dataset20M-1800').
+  when({
+    "$init": function() {
+      return {
+        count: 0
+      }
+    },
+    "$any": function(s, e) {
+      s.count = s.count + 1;
+    }
+}).outputState();

--- a/db-client-java/src/test/resources/state-with-unknown-keynames.js
+++ b/db-client-java/src/test/resources/state-with-unknown-keynames.js
@@ -1,0 +1,8 @@
+fromStream('dataset20M-1800').
+  when({
+    "$any": function(s, e) {
+      s[e.streamId] = {
+        timeArrivedMillis: new Date().getTime()
+      }
+    }
+}).outputState();


### PR DESCRIPTION
Added functionality to create and get the result of a continuous projection.

A Projections API which provides functionality to create and get the result of a continuous projection.
Getting the result of a projection uses Jackson deserialization to avoid exposing the raw protobuf classes. 