### PR TITLE
Enable signing only when publishing.

### DIFF
--- a/db-client-java/build.gradle
+++ b/db-client-java/build.gradle
@@ -113,8 +113,11 @@ publishing {
         maven {
             url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
             credentials {
-                username = ossrhUsername
-                password = ossrhPassword
+                def publishLogin = project.hasProperty("ossrhUsername") ? project.getProperties().get("ossrhUsername") : ""
+                def publishPassword = project.hasProperty("ossrhPassword") ? project.getProperties().get("ossrhPassword") : ""
+
+                username = publishLogin
+                password = publishPassword
             }
         }
     }
@@ -124,6 +127,12 @@ signing {
     useGpgCmd()
     sign configurations.archives
     sign publishing.publications.mavenJava
+}
+
+tasks.withType(Sign) {
+    onlyIf {
+        gradle.taskGraph.hasTask(":db-client-java:publish")
+    }
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Before that patch, building the project on a machine not configured to publish on Maven Central resulted in that error:

```
> Task :db-client-java:signMavenJavaPublication FAILED
FAILURE: Build failed with an exception.
* What went wrong:
A problem was found with the configuration of task ':db-client-java:signMavenJavaPublication' (type 'Sign').
> No value has been specified for property 'signatory.keyId'.
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
```

This patch enables signing only if we want to publish.