### PR TITLE
Fix ignored ReadStreamOptions

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClient.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClient.java
@@ -44,7 +44,7 @@ public class EventStoreDBClient extends EventStoreDBClientBase {
     }
 
     public CompletableFuture<ReadResult> readStream(String streamName, ReadStreamOptions options) {
-        return this.readStream(streamName, Long.MAX_VALUE, ReadStreamOptions.get());
+        return this.readStream(streamName, Long.MAX_VALUE, options);
     }
 
     public CompletableFuture<ReadResult> readStream(String streamName, long maxCount, ReadStreamOptions options) {

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ReadStreamTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ReadStreamTests.java
@@ -1,5 +1,6 @@
 package com.eventstore.dbclient;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import testcontainers.module.EventStoreTestDBContainer;
@@ -38,6 +39,28 @@ public class ReadStreamTests {
                 .get();
 
         verifyAgainstTestData(result.getEvents(), "dataset20M-1800-e1999-e1990");
+    }
+
+    @Test
+    public void testReadStreamOptionsAreNotIgnoredInOverloadedMethod() throws Throwable {
+        EventStoreDBClient client = server.getClient();
+
+        ReadStreamOptions options = ReadStreamOptions.get()
+                .backwards()
+                .fromEnd()
+                .notResolveLinkTos();
+
+        ReadResult result1 = client.readStream("dataset20M-1800", Long.MAX_VALUE, options)
+                .get();
+
+        ReadResult result2 = client.readStream("dataset20M-1800", options)
+                .get();
+
+        RecordedEvent firstEvent1 = result1.getEvents().get(0).getOriginalEvent();
+        RecordedEvent firstEvent2 = result2.getEvents().get(0).getOriginalEvent();
+
+        Assert.assertEquals(result1.getEvents().size(), result2.getEvents().size());
+        Assert.assertEquals(firstEvent1.getEventId(), firstEvent2.getEventId());
     }
 
     private void verifyAgainstTestData(List<ResolvedEvent> actualEvents, String filenameStem) {


### PR DESCRIPTION
In overloaded EventStoreDBClient#readStream(stream name, read options) method, options were ignored. Fixed it.