### PR TITLE
Allow running tests against different image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ and providing your personal access token as a password.
 
 Check full instructions in the ["Authenticating to GitHub packages"](https://docs.github.com/en/free-pro-team@latest/packages/guides/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages) guide.
 
+Specific docker images can be specified via the enviroment variable `EVENTSTORE_IMAGE`.
+
 ## EventStoreDB Server Compatibility
 
 This client is compatible with version `20.6.1` upwards.

--- a/db-client-java/src/test/java/testcontainers/module/EventStoreTestDBContainer.java
+++ b/db-client-java/src/test/java/testcontainers/module/EventStoreTestDBContainer.java
@@ -5,6 +5,8 @@ import com.github.dockerjava.api.model.HealthCheck;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.util.Optional;
+
 public class EventStoreTestDBContainer extends GenericContainer<EventStoreTestDBContainer> {
     public static final String NAME;
     public static final String IMAGE;
@@ -23,16 +25,21 @@ public class EventStoreTestDBContainer extends GenericContainer<EventStoreTestDB
         DB_HTTP_PORT = 2113;
     }
 
+    private static String getImageName() {
+        return Optional.ofNullable(System.getenv("EVENTSTORE_IMAGE"))
+                .orElse(IMAGE + ":" + IMAGE_TAG);
+    }
+
     public EventStoreTestDBContainer() {
         this(true);
     }
 
     public EventStoreTestDBContainer(boolean emptyDatabase) {
-        this(IMAGE + ":" + IMAGE_TAG, emptyDatabase);
+        this(getImageName(), emptyDatabase);
     }
 
     public EventStoreTestDBContainer(boolean emptyDatabase, boolean runProjections) {
-        this(IMAGE + ":" + IMAGE_TAG, emptyDatabase, runProjections);
+        this(getImageName(), emptyDatabase, runProjections);
     }
 
     public EventStoreTestDBContainer(String image, boolean emptyDatabase) {


### PR DESCRIPTION
Added an option to allow running the tests against a different image with the `EVENTSTORE_IMAGE` environment variable, same as the [NodeJS ](https://github.com/EventStore/EventStore-Client-NodeJS) client.