### PR TITLE
Persistent subscriptions to $all

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractCreatePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractCreatePersistentSubscription.java
@@ -1,0 +1,73 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
+import com.eventstore.dbclient.proto.persistentsubscriptions.PersistentSubscriptionsGrpc;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+public abstract class AbstractCreatePersistentSubscription {
+    private final GrpcClient client;
+    private final String group;
+    private final AbstractPersistentSubscriptionSettings settings;
+    private Metadata metadata;
+
+    public AbstractCreatePersistentSubscription(GrpcClient client, String group,
+                                                AbstractPersistentSubscriptionSettings settings, Metadata metadata) {
+        this.client = client;
+        this.group = group;
+        this.settings = settings;
+        this.metadata = metadata;
+    }
+
+    protected Persistent.CreateReq.Settings.Builder createSettings(){
+        return Persistent.CreateReq.Settings.newBuilder();
+    };
+
+    protected abstract Persistent.CreateReq.Options.Builder createOptions();
+
+    public CompletableFuture execute() {
+        return this.client.run(channel -> {
+            CompletableFuture result = new CompletableFuture();
+            PersistentSubscriptionsGrpc.PersistentSubscriptionsStub client = MetadataUtils
+                    .attachHeaders(PersistentSubscriptionsGrpc.newStub(channel), this.metadata);
+            Persistent.CreateReq.Settings.Builder settingsBuilder = createSettings();
+
+            settingsBuilder
+                    .setResolveLinks(settings.isResolveLinks())
+                    .setReadBatchSize(settings.getReadBatchSize())
+                    .setMinCheckpointCount(settings.getMinCheckpointCount())
+                    .setMaxCheckpointCount(settings.getMaxCheckpointCount())
+                    .setMessageTimeoutMs(settings.getMessageTimeoutMs())
+                    .setMaxSubscriberCount(settings.getMaxSubscriberCount())
+                    .setMaxRetryCount(settings.getMaxRetryCount())
+                    .setLiveBufferSize(settings.getLiveBufferSize())
+                    .setHistoryBufferSize(settings.getHistoryBufferSize())
+                    .setExtraStatistics(settings.isExtraStatistics())
+                    .setCheckpointAfterMs(settings.getCheckpointAfterMs());
+
+            switch (settings.getConsumerStrategyName()) {
+                case NamedConsumerStrategy.DISPATCH_TO_SINGLE:
+                    settingsBuilder.setNamedConsumerStrategy(Persistent.CreateReq.ConsumerStrategy.DispatchToSingle);
+                    break;
+                case NamedConsumerStrategy.ROUND_ROBIN:
+                    settingsBuilder.setNamedConsumerStrategy(Persistent.CreateReq.ConsumerStrategy.RoundRobin);
+                    break;
+                case NamedConsumerStrategy.PINNED:
+                    settingsBuilder.setNamedConsumerStrategy(Persistent.CreateReq.ConsumerStrategy.Pinned);
+                    break;
+            }
+
+            Persistent.CreateReq req = Persistent.CreateReq.newBuilder()
+                    .setOptions(createOptions()
+                        .setSettings(settingsBuilder)
+                        .setGroupName(group))
+                    .build();
+
+            client.create(req, GrpcUtils.convertSingleResponse(result));
+
+            return result;
+        });
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractDeletePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractDeletePersistentSubscription.java
@@ -1,0 +1,40 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
+import com.eventstore.dbclient.proto.persistentsubscriptions.PersistentSubscriptionsGrpc;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+public abstract class AbstractDeletePersistentSubscription {
+    private final GrpcClient client;
+    private final String group;
+    private final DeletePersistentSubscriptionOptions options;
+
+    public AbstractDeletePersistentSubscription(GrpcClient client, String group, DeletePersistentSubscriptionOptions options) {
+        this.client = client;
+        this.group = group;
+        this.options = options;
+    }
+
+    protected abstract Persistent.DeleteReq.Options.Builder createOptions();
+
+    public CompletableFuture execute() {
+        return this.client.run(channel -> {
+            CompletableFuture result = new CompletableFuture();
+            Metadata headers = this.options.getMetadata();
+            PersistentSubscriptionsGrpc.PersistentSubscriptionsStub client = MetadataUtils
+                    .attachHeaders(PersistentSubscriptionsGrpc.newStub(channel), headers);
+
+            Persistent.DeleteReq req = Persistent.DeleteReq.newBuilder()
+                    .setOptions(createOptions()
+                            .setGroupName(group))
+                    .build();
+
+            client.delete(req, GrpcUtils.convertSingleResponse(result));
+
+            return result;
+        });
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractPersistentSubscriptionSettings.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractPersistentSubscriptionSettings.java
@@ -1,0 +1,172 @@
+package com.eventstore.dbclient;
+
+import java.time.Duration;
+
+public abstract class AbstractPersistentSubscriptionSettings<T> {
+    private int checkpointAfterMs;
+    private boolean extraStatistics;
+    private boolean resolveLinkTos;
+    private int historyBufferSize;
+    private int liveBufferSize;
+    private int checkPointUpperBound;
+    private int maxRetryCount;
+    private int maxSubscriberCount;
+    private int messageTimeoutMs;
+    private int checkPointLowerBound;
+    private int readBatchSize;
+    private String consumerStrategyName;
+
+    public AbstractPersistentSubscriptionSettings(int checkpointAfterMs, boolean extraStatistics, boolean resolveLinks,
+                                                  int historyBufferSize, int liveBufferSize, int checkPointUpperBound,
+                                                  int maxRetryCount, int maxSubscriberCount, int messageTimeoutMs,
+                                                  int minCheckpointCount, int readBatchSize, String consumerStrategyName) {
+        this.checkpointAfterMs = checkpointAfterMs;
+        this.extraStatistics = extraStatistics;
+        this.resolveLinkTos = resolveLinks;
+        this.historyBufferSize = historyBufferSize;
+        this.liveBufferSize = liveBufferSize;
+        this.checkPointUpperBound = checkPointUpperBound;
+        this.maxRetryCount = maxRetryCount;
+        this.maxSubscriberCount = maxSubscriberCount;
+        this.messageTimeoutMs = messageTimeoutMs;
+        this.checkPointLowerBound = minCheckpointCount;
+        this.readBatchSize = readBatchSize;
+        this.consumerStrategyName = consumerStrategyName;
+    }
+
+    /**
+     * The amount of time in milliseconds to try to checkpoint after.
+     */
+    public int getCheckpointAfterMs() {
+        return checkpointAfterMs;
+    }
+
+    /**
+     * The amount of time to try to checkpoint after.
+     */
+    public Duration getCheckpointAfter() {
+        return Duration.ofMillis(checkpointAfterMs);
+    }
+
+    /**
+     * Whether to track latency statistics on this subscription.
+     */
+    public boolean isExtraStatistics() {
+        return extraStatistics;
+    }
+
+    /**
+     * @deprecated prefer {@link #shouldResolveLinkTos()}
+     */
+    public boolean isResolveLinks() {
+        return shouldResolveLinkTos();
+    }
+
+    /**
+     * Whether the subscription should resolve linkTo events to their linked events.
+     */
+    public boolean shouldResolveLinkTos() {
+        return resolveLinkTos;
+    }
+
+    /**
+     * The number of events to cache when catching up. Default 500.
+     */
+    public int getHistoryBufferSize() {
+        return historyBufferSize;
+    }
+
+    /**
+     * The size of the buffer (in-memory) listening to live messages as they happen before paging occurs. Default 500.
+     */
+    public int getLiveBufferSize() {
+        return liveBufferSize;
+    }
+
+    /**
+     * @deprecated prefer {@link #getCheckPointUpperBound()}
+     */
+    @Deprecated
+    public int getMaxCheckpointCount() {
+        return this.getCheckPointUpperBound();
+    }
+
+    /**
+     * The maximum number of messages not checkpointed before forcing a checkpoint.
+     */
+    public int getCheckPointUpperBound() {
+        return checkPointUpperBound;
+    }
+
+    /**
+     * The maximum number of retries (due to timeout) before a message is considered to be parked.
+     */
+    public int getMaxRetryCount() {
+        return maxRetryCount;
+    }
+
+    /**
+     * The maximum number of subscribers allowed.
+     */
+    public int getMaxSubscriberCount() {
+        return maxSubscriberCount;
+    }
+
+    /**
+     * The amount of time after which to consider a message as timed out and retried.
+     */
+    public Duration getMessageTimeout() {
+        return Duration.ofMillis(messageTimeoutMs);
+    }
+
+    /**
+     * The amount of time in milliseconds after which to consider a message as timed out and retried.
+     */
+    public int getMessageTimeoutMs() {
+        return messageTimeoutMs;
+    }
+
+    /**
+     * @deprecated prefer {@link #getCheckPointLowerBound()}
+     */
+    @Deprecated
+    public int getMinCheckpointCount() {
+        return this.getCheckPointLowerBound();
+    }
+
+    /**
+     * The minimum number of messages to process before a checkpoint may be written.
+     */
+    public int getCheckPointLowerBound() {
+        return checkPointLowerBound;
+    }
+
+    /**
+     * The number of events read at a time when catching up.
+     */
+    public int getReadBatchSize() {
+        return readBatchSize;
+    }
+
+    /**
+     * @deprecated prefer {@link #getConsumerStrategyName()}
+     */
+    @Deprecated
+    public ConsumerStrategy getStrategy() throws Exception {
+
+        switch (consumerStrategyName){
+            case NamedConsumerStrategy.DISPATCH_TO_SINGLE: return ConsumerStrategy.DispatchToSingle;
+            case NamedConsumerStrategy.ROUND_ROBIN: return ConsumerStrategy.RoundRobin;
+            case NamedConsumerStrategy.PINNED: return ConsumerStrategy.Pinned;
+        }
+
+        throw new Exception("Non-default ConsumerStrategy specified, use getConsumerStrategyName()");
+    }
+
+    /**
+     * The strategy to use for distributing events to client consumers.
+     */
+    public String getConsumerStrategyName() {
+        return consumerStrategyName;
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractPersistentSubscriptionSettingsBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractPersistentSubscriptionSettingsBuilder.java
@@ -1,0 +1,235 @@
+package com.eventstore.dbclient;
+
+import java.time.Duration;
+
+public class AbstractPersistentSubscriptionSettingsBuilder<T> {
+    protected int checkpointAfterMs;
+    protected boolean extraStatistics;
+    protected boolean resolveLinkTos;
+    protected int historyBufferSize;
+    protected int liveBufferSize;
+    protected int checkPointUpperBound;
+    protected int maxRetryCount;
+    protected int maxSubscriberCount;
+    protected int messageTimeoutMs;
+    protected int checkPointLowerBound;
+    protected int readBatchSize;
+    protected String consumerStrategyName;
+
+    public AbstractPersistentSubscriptionSettingsBuilder() {
+        checkpointAfterMs = 2_000;
+        resolveLinkTos = false;
+        extraStatistics = false;
+        messageTimeoutMs = 30_000;
+        maxRetryCount = 10;
+        checkPointLowerBound = 10;
+        checkPointUpperBound = 1_000;
+        maxSubscriberCount = 0;
+        liveBufferSize = 500;
+        readBatchSize = 20;
+        historyBufferSize = 500;
+        consumerStrategyName = NamedConsumerStrategy.ROUND_ROBIN;
+    }
+
+    public AbstractPersistentSubscriptionSettingsBuilder(AbstractPersistentSubscriptionSettings settings) {
+        checkpointAfterMs = settings.getCheckpointAfterMs();
+        resolveLinkTos = settings.shouldResolveLinkTos();
+        extraStatistics = settings.isExtraStatistics();
+        messageTimeoutMs = settings.getMessageTimeoutMs();
+        maxRetryCount = settings.getMaxRetryCount();
+        checkPointLowerBound = settings.getCheckPointLowerBound();
+        checkPointUpperBound = settings.getCheckPointUpperBound();
+        maxSubscriberCount = settings.getMaxSubscriberCount();
+        liveBufferSize = settings.getLiveBufferSize();
+        readBatchSize = settings.getReadBatchSize();
+        historyBufferSize = settings.getHistoryBufferSize();
+        consumerStrategyName = settings.getConsumerStrategyName();
+    }
+
+    /**
+     * @deprecated prefer {@link #resolveLinkTos()}
+     */
+    @Deprecated
+    public T enableLinkResolution() {
+        return resolveLinks(true);
+    }
+
+    /**
+     * @deprecated prefer {@link #notResolveLinkTos()}
+     */
+    @Deprecated
+    public T disableLinkResolution() {
+        return resolveLinks(false);
+    }
+
+    /**
+     * @deprecated prefer {@link #resolveLinkTos(boolean)}
+     */
+    @Deprecated
+    public T resolveLinks(boolean value) {
+        return (T) resolveLinkTos(value);
+    }
+
+    /**
+     * Whether the subscription should resolve linkTo events to their linked events. Default: false.
+     */
+    public T resolveLinkTos(boolean value) {
+        this.resolveLinkTos = value;
+        return (T) this;
+    }
+
+    /**
+     * Resolve linkTo events to their linked events.
+     */
+    public T resolveLinkTos() {
+        return this.resolveLinkTos(true);
+    }
+
+    /**
+     * Don't resolve linkTo events to their linked events.
+     */
+    public T notResolveLinkTos() {
+        return this.resolveLinkTos(false);
+    }
+
+    /**
+     * Enable tracking of latency statistics on this subscription.
+     */
+    public T enableExtraStatistics() {
+        return extraStatistics(true);
+    }
+
+    /**
+     * Disable tracking of latency statistics on this subscription.
+     */
+    public T disableExtraStatistics() {
+        return extraStatistics(false);
+    }
+
+    /**
+     * Whether to track latency statistics on this subscription. Default: false.
+     */
+    public T extraStatistics(boolean value) {
+        this.extraStatistics = value;
+        return (T) this;
+    }
+
+    /**
+     * The amount of time to try to checkpoint after. Default: 2 seconds.
+     */
+    public T checkpointAfter(Duration value) {
+        this.checkpointAfterInMs((int)value.toMillis());
+        return (T) this;
+    }
+
+    /**
+     * The amount of time in milliseconds to try to checkpoint after. Default: 2 seconds.
+     */
+    public T checkpointAfterInMs(int value) {
+        this.checkpointAfterMs = value;
+        return (T) this;
+    }
+
+    /**
+     * The number of events to cache when catching up. Default: 500.
+     */
+    public T historyBufferSize(int value) {
+        this.historyBufferSize = value;
+        return (T) this;
+    }
+
+    /**
+     * The size of the buffer (in-memory) listening to live messages as they happen before paging occurs. Default: 500.
+     */
+    public T liveBufferSize(int value) {
+        this.liveBufferSize = value;
+        return (T) this;
+    }
+
+    /**
+     * @deprecated prefer {@link #checkPointUpperBound(int)}
+     */
+    @Deprecated
+    public T maxCheckpointCount(int value) {
+        return checkPointUpperBound(value);
+    }
+
+    /**
+     * The maximum number of messages not checkpointed before forcing a checkpoint. Default: 1000.
+     */
+    public T checkPointUpperBound(int value) {
+        this.checkPointUpperBound = value;
+        return (T) this;
+    }
+
+    /**
+     * @deprecated prefer {@link #checkPointLowerBound(int)}
+     */
+    @Deprecated
+    public T minCheckpointCount(int value) {
+        return this.checkPointLowerBound(checkPointLowerBound);
+    }
+
+    /**
+     * The minimum number of messages to process before a checkpoint may be written. Default: 10.
+     */
+    public T checkPointLowerBound(int value) {
+        this.checkPointLowerBound = value;
+        return (T) this;
+    }
+
+    /**
+     * The maximum number of subscribers allowed. Default: 0 (Unbounded).
+     */
+    public T maxSubscriberCount(int value) {
+        this.maxSubscriberCount = value;
+        return (T) this;
+    }
+
+    /**
+     * The maximum number of retries (due to timeout) before a message is considered to be parked. Default: 10.
+     */
+    public T maxRetryCount(int value) {
+        this.maxRetryCount = value;
+        return (T) this;
+    }
+
+    /**
+     * The amount of time after which to consider a message as timed out and retried. Default: 30 seconds.
+     */
+    public T messageTimeout(Duration value) {
+        return this.messageTimeoutInMs((int)value.toMillis());
+    }
+
+    /**
+     * The amount of time in milliseconds after which to consider a message as timed out and retried. Default: 30 seconds.
+     */
+    public T messageTimeoutInMs(int value) {
+        this.messageTimeoutMs = value;
+        return (T) this;
+    }
+
+    /**
+     * The number of events read at a time when catching up. Default: 20.
+     */
+    public T readBatchSize(int value) {
+        this.readBatchSize = value;
+        return (T) this;
+    }
+
+    /**
+     * The strategy to use for distributing events to client consumers.
+     */
+    public T consumerStrategy(ConsumerStrategy strategy) {
+        this.consumerStrategyName = NamedConsumerStrategy.from(strategy);
+        return (T) this;
+    }
+
+    /**
+     * The strategy to use for distributing events to client consumers.
+     */
+    public T namedConsumerStrategy(String value) {
+        this.consumerStrategyName = value;
+        return (T) this;
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
@@ -1,0 +1,116 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
+import com.eventstore.dbclient.proto.persistentsubscriptions.PersistentSubscriptionsGrpc;
+import com.eventstore.dbclient.proto.shared.Shared;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.grpc.stub.MetadataUtils;
+import io.grpc.stub.StreamObserver;
+
+import java.util.concurrent.CompletableFuture;
+
+public abstract class AbstractSubscribePersistentSubscription {
+    protected static final Persistent.ReadReq.Options.Builder defaultReadOptions;
+    private final GrpcClient connection;
+    private final String group;
+    private final PersistentSubscriptionListener listener;
+    private final SubscribePersistentSubscriptionOptions options;
+
+    static {
+        defaultReadOptions = Persistent.ReadReq.Options.newBuilder()
+                .setUuidOption(Persistent.ReadReq.Options.UUIDOption.newBuilder()
+                        .setStructured(Shared.Empty.getDefaultInstance()));
+    }
+
+    public AbstractSubscribePersistentSubscription(GrpcClient connection, String group,
+                                                   SubscribePersistentSubscriptionOptions options,
+                                                   PersistentSubscriptionListener listener) {
+        this.connection = connection;
+        this.group = group;
+        this.options = options;
+        this.listener = listener;
+    }
+
+    protected abstract Persistent.ReadReq.Options.Builder createOptions();
+
+    public CompletableFuture execute() {
+        return this.connection.run(channel -> {
+            Metadata headers = this.options.getMetadata();
+            PersistentSubscriptionsGrpc.PersistentSubscriptionsStub client = MetadataUtils
+                    .attachHeaders(PersistentSubscriptionsGrpc.newStub(channel), headers);
+
+            final CompletableFuture<PersistentSubscription> result = new CompletableFuture<>();
+
+            int bufferSize = this.options.getBufferSize();
+
+            Persistent.ReadReq req = Persistent.ReadReq.newBuilder()
+                    .setOptions(createOptions()
+                            .setBufferSize(bufferSize)
+                            .setGroupName(group))
+                    .build();
+
+            ClientResponseObserver<Persistent.ReadReq, Persistent.ReadResp> observer = new ClientResponseObserver<Persistent.ReadReq, Persistent.ReadResp>() {
+                private boolean _confirmed;
+                private PersistentSubscription _subscription;
+                private ClientCallStreamObserver<Persistent.ReadReq> _requestStream;
+
+                @Override
+                public void beforeStart(ClientCallStreamObserver<Persistent.ReadReq> requestStream) {
+                    this._requestStream = requestStream;
+                }
+
+                @Override
+                public void onNext(Persistent.ReadResp readResp) {
+                    if (!_confirmed && readResp.hasSubscriptionConfirmation()) {
+                        this._confirmed = true;
+                        this._subscription = new PersistentSubscription(this._requestStream,
+                                readResp.getSubscriptionConfirmation().getSubscriptionId());
+                        result.complete(this._subscription);
+                        return;
+                    }
+
+                    if (!_confirmed && readResp.hasEvent()) {
+                        onError(new IllegalStateException("Unconfirmed persistent subscription received event"));
+                        return;
+                    }
+
+                    if (_confirmed && !readResp.hasEvent()) {
+                        onError(new IllegalStateException(
+                                String.format("Confirmed persistent subscription %s received non-{event,checkpoint} variant",
+                                        _subscription.getSubscriptionId())));
+                        return;
+                    }
+
+                    listener.onEvent(this._subscription, ResolvedEvent.fromWire(readResp.getEvent()));
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    if (t instanceof StatusRuntimeException) {
+                        Status s = ((StatusRuntimeException) t).getStatus();
+                        if (s.getCode() == Status.Code.CANCELLED) {
+                            listener.onCancelled(this._subscription);
+                            return;
+                        }
+                    }
+
+                    listener.onError(this._subscription, t);
+                }
+
+                @Override
+                public void onCompleted() {
+                    // Subscriptions should only complete on error.
+                }
+            };
+
+            StreamObserver<Persistent.ReadReq> wireStream = client.read(observer);
+            wireStream.onNext(req);
+
+            return result;
+        });
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractUpdatePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractUpdatePersistentSubscription.java
@@ -1,0 +1,73 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
+import com.eventstore.dbclient.proto.persistentsubscriptions.PersistentSubscriptionsGrpc;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+public abstract class AbstractUpdatePersistentSubscription {
+    private final GrpcClient connection;
+    private final String group;
+    private final AbstractPersistentSubscriptionSettings settings;
+    private Metadata metadata;
+
+    public AbstractUpdatePersistentSubscription(GrpcClient connection, String group,
+                                                AbstractPersistentSubscriptionSettings settings, Metadata metadata) {
+        this.connection = connection;
+        this.group = group;
+        this.settings = settings;
+        this.metadata = metadata;
+    }
+
+    protected Persistent.UpdateReq.Settings.Builder createSettings() {
+        return Persistent.UpdateReq.Settings.newBuilder();
+    }
+
+    protected abstract Persistent.UpdateReq.Options.Builder createOptions();
+
+    public CompletableFuture execute() {
+        return this.connection.run(channel -> {
+            CompletableFuture result = new CompletableFuture();
+            PersistentSubscriptionsGrpc.PersistentSubscriptionsStub client = MetadataUtils
+                    .attachHeaders(PersistentSubscriptionsGrpc.newStub(channel), metadata);
+            Persistent.UpdateReq.Settings.Builder settingsBuilder = createSettings();
+
+            settingsBuilder
+                    .setResolveLinks(settings.isResolveLinks())
+                    .setReadBatchSize(settings.getReadBatchSize())
+                    .setMinCheckpointCount(settings.getMinCheckpointCount())
+                    .setMaxCheckpointCount(settings.getMaxCheckpointCount())
+                    .setMessageTimeoutMs(settings.getMessageTimeoutMs())
+                    .setMaxSubscriberCount(settings.getMaxSubscriberCount())
+                    .setMaxRetryCount(settings.getMaxRetryCount())
+                    .setLiveBufferSize(settings.getLiveBufferSize())
+                    .setHistoryBufferSize(settings.getHistoryBufferSize())
+                    .setExtraStatistics(settings.isExtraStatistics())
+                    .setCheckpointAfterMs(settings.getCheckpointAfterMs());
+
+            switch (settings.getConsumerStrategyName()) {
+                case NamedConsumerStrategy.DISPATCH_TO_SINGLE:
+                    settingsBuilder.setNamedConsumerStrategy(Persistent.UpdateReq.ConsumerStrategy.DispatchToSingle);
+                    break;
+                case NamedConsumerStrategy.ROUND_ROBIN:
+                    settingsBuilder.setNamedConsumerStrategy(Persistent.UpdateReq.ConsumerStrategy.RoundRobin);
+                    break;
+                case NamedConsumerStrategy.PINNED:
+                    settingsBuilder.setNamedConsumerStrategy(Persistent.UpdateReq.ConsumerStrategy.Pinned);
+                    break;
+            }
+
+            Persistent.UpdateReq req = Persistent.UpdateReq.newBuilder()
+                    .setOptions(createOptions()
+                            .setSettings(settingsBuilder)
+                            .setGroupName(group))
+                    .build();
+
+            client.update(req, GrpcUtils.convertSingleResponse(result));
+
+            return result;
+        });
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/CreatePersistentSubscriptionOptions.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/CreatePersistentSubscriptionOptions.java
@@ -1,7 +1,9 @@
 package com.eventstore.dbclient;
 
-public class CreatePersistentSubscriptionOptions extends ManagePersistentSubscriptionOptionsBase<CreatePersistentSubscriptionOptions> {
-    private CreatePersistentSubscriptionOptions() {
+public class CreatePersistentSubscriptionOptions
+        extends ManagePersistentSubscriptionOptionsBase<CreatePersistentSubscriptionOptions, PersistentSubscriptionSettings> {
+    protected CreatePersistentSubscriptionOptions() {
+        super(PersistentSubscriptionSettings.builder().build());
     }
 
     public static CreatePersistentSubscriptionOptions get() {

--- a/db-client-java/src/main/java/com/eventstore/dbclient/CreatePersistentSubscriptionToAll.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/CreatePersistentSubscriptionToAll.java
@@ -1,0 +1,36 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
+import com.eventstore.dbclient.proto.shared.Shared;
+
+public class CreatePersistentSubscriptionToAll extends AbstractCreatePersistentSubscription {
+    private final PersistentSubscriptionToAllSettings settings;
+
+    public CreatePersistentSubscriptionToAll(GrpcClient client, String group,
+                                             CreatePersistentSubscriptionToAllOptions options) {
+        super(client, group, options.getSettings(), options.getMetadata());
+
+        this.settings = options.getSettings();
+    }
+
+    @Override
+    protected Persistent.CreateReq.Options.Builder createOptions() {
+        Persistent.CreateReq.Options.Builder optionsBuilder = Persistent.CreateReq.Options.newBuilder();
+        Persistent.CreateReq.AllOptions.Builder allOptionsBuilder = Persistent.CreateReq.AllOptions.newBuilder();
+
+        if (settings.getPosition() == Position.START) {
+            allOptionsBuilder.setStart(Shared.Empty.newBuilder());
+        } else if (settings.getPosition() == Position.END) {
+            allOptionsBuilder.setEnd(Shared.Empty.newBuilder());
+        } else {
+            Position position = settings.getPosition();
+            allOptionsBuilder.setPosition(Persistent.CreateReq.Position.newBuilder()
+                    .setCommitPosition(position.getCommitUnsigned())
+                    .setPreparePosition(position.getPrepareUnsigned()));
+        }
+
+        optionsBuilder.setAll(allOptionsBuilder);
+
+        return optionsBuilder;
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/CreatePersistentSubscriptionToAllOptions.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/CreatePersistentSubscriptionToAllOptions.java
@@ -1,0 +1,12 @@
+package com.eventstore.dbclient;
+
+public class CreatePersistentSubscriptionToAllOptions
+        extends ManagePersistentSubscriptionOptionsBase<CreatePersistentSubscriptionToAllOptions, PersistentSubscriptionToAllSettings> {
+    protected CreatePersistentSubscriptionToAllOptions() {
+        super(PersistentSubscriptionToAllSettings.builder().build());
+    }
+
+    public static CreatePersistentSubscriptionToAllOptions get() {
+        return new CreatePersistentSubscriptionToAllOptions();
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/DeletePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/DeletePersistentSubscription.java
@@ -1,51 +1,25 @@
 package com.eventstore.dbclient;
 
 import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
-import com.eventstore.dbclient.proto.persistentsubscriptions.PersistentSubscriptionsGrpc;
 import com.eventstore.dbclient.proto.shared.Shared;
 import com.google.protobuf.ByteString;
-import io.grpc.Metadata;
-import io.grpc.stub.MetadataUtils;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
+public class DeletePersistentSubscription extends AbstractDeletePersistentSubscription {
+    private String stream;
 
-public class DeletePersistentSubscription {
-    private final GrpcClient client;
-    private final String stream;
-    private final String group;
-    private final DeletePersistentSubscriptionOptions options;
-
-    public DeletePersistentSubscription(GrpcClient client, String stream, String group, DeletePersistentSubscriptionOptions options) {
-        this.client = client;
+    public DeletePersistentSubscription(GrpcClient client, String stream, String group,
+                                        DeletePersistentSubscriptionOptions options) {
+        super(client, group, options);
         this.stream = stream;
-        this.group = group;
-        this.options = options;
     }
 
-    public CompletableFuture execute() {
-        return this.client.run(channel -> {
-            CompletableFuture result = new CompletableFuture();
-            Metadata headers = this.options.getMetadata();
-            PersistentSubscriptionsGrpc.PersistentSubscriptionsStub client = MetadataUtils.attachHeaders(PersistentSubscriptionsGrpc.newStub(channel), headers);
+    @Override
+    protected Persistent.DeleteReq.Options.Builder createOptions() {
+        Shared.StreamIdentifier.Builder streamIdentifier =
+                Shared.StreamIdentifier.newBuilder()
+                        .setStreamName(ByteString.copyFromUtf8(stream));
 
-            Shared.StreamIdentifier streamIdentifier =
-                    Shared.StreamIdentifier.newBuilder()
-                            .setStreamName(ByteString.copyFromUtf8(stream))
-                            .build();
-
-            Persistent.DeleteReq.Options options = Persistent.DeleteReq.Options.newBuilder()
-                    .setStreamIdentifier(streamIdentifier)
-                    .setGroupName(group)
-                    .build();
-
-            Persistent.DeleteReq req = Persistent.DeleteReq.newBuilder()
-                    .setOptions(options)
-                    .build();
-
-            client.delete(req, GrpcUtils.convertSingleResponse(result));
-
-            return result;
-        });
+        return Persistent.DeleteReq.Options.newBuilder()
+                .setStreamIdentifier(streamIdentifier);
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/DeletePersistentSubscriptionToAll.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/DeletePersistentSubscriptionToAll.java
@@ -1,0 +1,17 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
+import com.eventstore.dbclient.proto.shared.Shared;
+
+public class DeletePersistentSubscriptionToAll extends AbstractDeletePersistentSubscription {
+    public DeletePersistentSubscriptionToAll(GrpcClient client, String group,
+                                             DeletePersistentSubscriptionOptions options) {
+        super(client, group, options);
+    }
+
+    @Override
+    protected Persistent.DeleteReq.Options.Builder createOptions() {
+        return Persistent.DeleteReq.Options.newBuilder()
+                .setAll(Shared.Empty.newBuilder());
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBPersistentSubscriptionsClient.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBPersistentSubscriptionsClient.java
@@ -15,6 +15,10 @@ public class EventStoreDBPersistentSubscriptionsClient extends EventStoreDBClien
         return this.create(stream, group, CreatePersistentSubscriptionOptions.get());
     }
 
+    public CompletableFuture createToAll(String group) {
+        return this.createToAll(group, CreatePersistentSubscriptionToAllOptions.get());
+    }
+
     public CompletableFuture create(String stream, String group, PersistentSubscriptionSettings settings) {
         CreatePersistentSubscriptionOptions options = CreatePersistentSubscriptionOptions.get()
                 .settings(settings);
@@ -22,9 +26,17 @@ public class EventStoreDBPersistentSubscriptionsClient extends EventStoreDBClien
         return this.create(stream, group, options);
     }
 
+    public CompletableFuture createToAll(String group, PersistentSubscriptionToAllSettings settings) {
+        CreatePersistentSubscriptionToAllOptions options = CreatePersistentSubscriptionToAllOptions.get()
+                .settings(settings);
+
+        return this.createToAll(group, options);
+    }
+
     public CompletableFuture create(String stream, String group, CreatePersistentSubscriptionOptions options) {
-        if (options == null)
+        if (options == null) {
             options = CreatePersistentSubscriptionOptions.get();
+        }
 
         if (!options.hasUserCredentials()) {
             options.authenticated(this.credentials);
@@ -33,8 +45,24 @@ public class EventStoreDBPersistentSubscriptionsClient extends EventStoreDBClien
         return new CreatePersistentSubscription(this.client, stream, group, options).execute();
     }
 
+    public CompletableFuture createToAll(String group, CreatePersistentSubscriptionToAllOptions options) {
+        if (options == null) {
+            options = CreatePersistentSubscriptionToAllOptions.get();
+        }
+
+        if (!options.hasUserCredentials()) {
+            options.authenticated(this.credentials);
+        }
+
+        return new CreatePersistentSubscriptionToAll(this.client, group, options).execute();
+    }
+
     public CompletableFuture update(String stream, String group) {
         return this.update(stream, group, UpdatePersistentSubscriptionOptions.get());
+    }
+
+    public CompletableFuture updateToAll(String group) {
+        return this.updateToAll(group, UpdatePersistentSubscriptionToAllOptions.get());
     }
 
     public CompletableFuture update(String stream, String group, PersistentSubscriptionSettings settings) {
@@ -44,9 +72,17 @@ public class EventStoreDBPersistentSubscriptionsClient extends EventStoreDBClien
         return this.update(stream, group, options);
     }
 
+    public CompletableFuture updateToAll(String group, PersistentSubscriptionToAllSettings settings) {
+        UpdatePersistentSubscriptionToAllOptions options = UpdatePersistentSubscriptionToAllOptions.get()
+                .settings(settings);
+
+        return this.updateToAll(group, options);
+    }
+
     public CompletableFuture update(String stream, String group, UpdatePersistentSubscriptionOptions options) {
-        if (options == null)
+        if (options == null) {
             options = UpdatePersistentSubscriptionOptions.get();
+        }
 
         if (!options.hasUserCredentials()) {
             options.authenticated(this.credentials);
@@ -55,33 +91,77 @@ public class EventStoreDBPersistentSubscriptionsClient extends EventStoreDBClien
         return new UpdatePersistentSubscription(this.client, stream, group, options).execute();
     }
 
+    public CompletableFuture updateToAll(String group, UpdatePersistentSubscriptionToAllOptions options) {
+        if (options == null) {
+            options = UpdatePersistentSubscriptionToAllOptions.get();
+        }
+
+        if (!options.hasUserCredentials()) {
+            options.authenticated(this.credentials);
+        }
+
+        return new UpdatePersistentSubscriptionToAll(this.client, group, options).execute();
+    }
+
     public CompletableFuture delete(String stream, String group) {
         return this.delete(stream, group, DeletePersistentSubscriptionOptions.get());
     }
 
+    public CompletableFuture deleteToAll(String group) {
+        return this.deleteToAll(group, DeletePersistentSubscriptionOptions.get());
+    }
+
     public CompletableFuture delete(String stream, String group, DeletePersistentSubscriptionOptions options) {
-        if (options == null)
+        if (options == null) {
             options = DeletePersistentSubscriptionOptions.get();
+        }
 
         if (!options.hasUserCredentials()) {
             options.authenticated(this.credentials);
         }
 
-        return new DeletePersistentSubscription(this.client, stream, group, options).execute();
+        return new DeletePersistentSubscription(this.client, stream, group, options).execute();    }
+
+    public CompletableFuture deleteToAll(String group, DeletePersistentSubscriptionOptions options) {
+        if (options == null) {
+            options = DeletePersistentSubscriptionOptions.get();
+        }
+
+        if (!options.hasUserCredentials()) {
+            options.authenticated(this.credentials);
+        }
+
+        return new DeletePersistentSubscriptionToAll(this.client, group, options).execute();
     }
 
     public CompletableFuture subscribe(String stream, String group, PersistentSubscriptionListener listener) {
-        return this.subscribe(stream, group, SubscribePersistentSubscriptionOptions.get(), listener);
+        return this.subscribe(stream, group, listener);
+    }
+
+    public CompletableFuture subscribeToAll(String group, PersistentSubscriptionListener listener) {
+        return this.subscribeToAll(group, SubscribePersistentSubscriptionOptions.get(), listener);
     }
 
     public CompletableFuture subscribe(String stream, String group, SubscribePersistentSubscriptionOptions options, PersistentSubscriptionListener listener) {
-        if (options == null)
+        if (options == null) {
             options = SubscribePersistentSubscriptionOptions.get();
+        }
 
         if (!options.hasUserCredentials()) {
             options.authenticated(this.credentials);
         }
 
-        return new SubscribePersistentSubscription(this.client, stream, group, options, listener).execute();
+        return new SubscribePersistentSubscription(this.client, stream, group, options, listener).execute();    }
+
+    public CompletableFuture subscribeToAll(String group, SubscribePersistentSubscriptionOptions options, PersistentSubscriptionListener listener) {
+        if (options == null) {
+            options = SubscribePersistentSubscriptionOptions.get();
+        }
+
+        if (!options.hasUserCredentials()) {
+            options.authenticated(this.credentials);
+        }
+
+        return new SubscribePersistentSubscriptionToAll(this.client, group, options, listener).execute();
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ManagePersistentSubscriptionOptionsBase.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ManagePersistentSubscriptionOptionsBase.java
@@ -1,19 +1,20 @@
 package com.eventstore.dbclient;
 
-class ManagePersistentSubscriptionOptionsBase<T> extends OptionsBase<T> {
-    private PersistentSubscriptionSettings settings;
+abstract class ManagePersistentSubscriptionOptionsBase<TO,TS> extends OptionsBase<TO> {
+    private TS settings;
 
-    protected ManagePersistentSubscriptionOptionsBase() {
-        this.settings = PersistentSubscriptionSettings.builder().build();
+    protected ManagePersistentSubscriptionOptionsBase(TS settings)
+    {
+        this.settings = settings;
     }
 
-    public T settings(PersistentSubscriptionSettings settings) {
+    public TO settings(TS settings) {
         this.settings = settings;
 
-        return (T)this;
+        return (TO)this;
     }
 
-    public PersistentSubscriptionSettings getSettings() {
+    public TS getSettings() {
         return settings;
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/NamedConsumerStrategy.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/NamedConsumerStrategy.java
@@ -1,0 +1,17 @@
+package com.eventstore.dbclient;
+
+public class NamedConsumerStrategy {
+    public static final String DISPATCH_TO_SINGLE = "DispatchToSingle";
+    public static final String ROUND_ROBIN = "RoundRobin";
+    public static final String PINNED = "Pinned";
+
+    public static String from(ConsumerStrategy strategy) {
+        switch (strategy){
+            case DispatchToSingle: return NamedConsumerStrategy.DISPATCH_TO_SINGLE;
+            case RoundRobin: return NamedConsumerStrategy.ROUND_ROBIN;
+            case Pinned: return NamedConsumerStrategy.PINNED;
+        }
+
+        throw new IllegalArgumentException("Unknown ConsumerStrategy specified!");
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscription.java
@@ -12,18 +12,18 @@ import java.util.Iterator;
 public class PersistentSubscription {
     private final ClientCallStreamObserver<Persistent.ReadReq> requestStream;
     private final String subscriptionId;
-    private final String streamName;
-    private final String groupName;
-    private final int bufferSize;
-    private final Persistent.ReadReq.Options.Builder options;
 
-    public PersistentSubscription(ClientCallStreamObserver<Persistent.ReadReq> requestStream, String subscriptionId, String streamName, String groupName, int bufferSize, Persistent.ReadReq.Options.Builder options) {
+    @Deprecated
+    public PersistentSubscription(ClientCallStreamObserver<Persistent.ReadReq> requestStream, String subscriptionId,
+                                  String streamName, String groupName, int bufferSize,
+                                  Persistent.ReadReq.Options.Builder options) {
         this.requestStream = requestStream;
         this.subscriptionId = subscriptionId;
-        this.streamName = streamName;
-        this.groupName = groupName;
-        this.bufferSize = bufferSize;
-        this.options = options;
+    }
+
+    public PersistentSubscription(ClientCallStreamObserver<Persistent.ReadReq> requestStream, String subscriptionId) {
+        this.requestStream = requestStream;
+        this.subscriptionId = subscriptionId;
     }
 
     public String getSubscriptionId() {

--- a/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionSettings.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionSettings.java
@@ -1,34 +1,35 @@
 package com.eventstore.dbclient;
 
-public class PersistentSubscriptionSettings {
-    private int checkpointAfterMs;
-    private boolean extraStatistics;
-    private boolean resolveLinks;
-    private int historyBufferSize;
-    private int liveBufferSize;
-    private int maxCheckpointCount;
-    private int maxRetryCount;
-    private int maxSubscriberCount;
-    private int messageTimeoutMs;
-    private int minCheckpointCount;
-    private int readBatchSize;
-    private long revision;
-    private ConsumerStrategy strategy;
+public class PersistentSubscriptionSettings extends AbstractPersistentSubscriptionSettings {
+    protected StreamRevision revision;
 
-    public PersistentSubscriptionSettings(int checkpointAfterMs, boolean extraStatistics, boolean resolveLinks, int historyBufferSize, int liveBufferSize, int maxCheckpointCount, int maxRetryCount, int maxSubscriberCount, int messageTimeoutMs, int minCheckpointCount, int readBatchSize, long revision, ConsumerStrategy strategy) {
-        this.checkpointAfterMs = checkpointAfterMs;
-        this.extraStatistics = extraStatistics;
-        this.resolveLinks = resolveLinks;
-        this.historyBufferSize = historyBufferSize;
-        this.liveBufferSize = liveBufferSize;
-        this.maxCheckpointCount = maxCheckpointCount;
-        this.maxRetryCount = maxRetryCount;
-        this.maxSubscriberCount = maxSubscriberCount;
-        this.messageTimeoutMs = messageTimeoutMs;
-        this.minCheckpointCount = minCheckpointCount;
-        this.readBatchSize = readBatchSize;
+    public PersistentSubscriptionSettings(int checkpointAfterMs, boolean extraStatistics, boolean resolveLinks,
+                                          int historyBufferSize, int liveBufferSize, int maxCheckpointCount,
+                                          int maxRetryCount, int maxSubscriberCount, int messageTimeoutMs,
+                                          int minCheckpointCount, int readBatchSize, long revision,
+                                          ConsumerStrategy strategy) {
+        this(checkpointAfterMs, extraStatistics, resolveLinks, historyBufferSize, liveBufferSize, maxCheckpointCount,
+                maxRetryCount, maxSubscriberCount, messageTimeoutMs, minCheckpointCount, readBatchSize,
+                new StreamRevision(revision), NamedConsumerStrategy.from(strategy));
+    }
+
+    public PersistentSubscriptionSettings(int checkpointAfterMs, boolean extraStatistics, boolean resolveLinks,
+                                          int historyBufferSize, int liveBufferSize, int maxCheckpointCount,
+                                          int maxRetryCount, int maxSubscriberCount, int messageTimeoutMs,
+                                          int minCheckpointCount, int readBatchSize, StreamRevision revision,
+                                          String consumerStrategyName) {
+        super(checkpointAfterMs, extraStatistics, resolveLinks, historyBufferSize, liveBufferSize, maxCheckpointCount,
+                maxRetryCount, maxSubscriberCount, messageTimeoutMs, minCheckpointCount, readBatchSize, consumerStrategyName);
+
         this.revision = revision;
-        this.strategy = strategy;
+    }
+
+    public long getRevision() {
+        return revision.getValueUnsigned();
+    }
+
+    public StreamRevision getStreamRevision() {
+        return revision;
     }
 
     public static PersistentSubscriptionSettingsBuilder builder() {
@@ -37,57 +38,5 @@ public class PersistentSubscriptionSettings {
 
     public static PersistentSubscriptionSettingsBuilder copy(PersistentSubscriptionSettings settings) {
         return new PersistentSubscriptionSettingsBuilder(settings);
-    }
-
-    public int getCheckpointAfterMs() {
-        return checkpointAfterMs;
-    }
-
-    public boolean isExtraStatistics() {
-        return extraStatistics;
-    }
-
-    public boolean isResolveLinks() {
-        return resolveLinks;
-    }
-
-    public int getHistoryBufferSize() {
-        return historyBufferSize;
-    }
-
-    public int getLiveBufferSize() {
-        return liveBufferSize;
-    }
-
-    public int getMaxCheckpointCount() {
-        return maxCheckpointCount;
-    }
-
-    public int getMaxRetryCount() {
-        return maxRetryCount;
-    }
-
-    public int getMaxSubscriberCount() {
-        return maxSubscriberCount;
-    }
-
-    public int getMessageTimeoutMs() {
-        return messageTimeoutMs;
-    }
-
-    public int getMinCheckpointCount() {
-        return minCheckpointCount;
-    }
-
-    public int getReadBatchSize() {
-        return readBatchSize;
-    }
-
-    public long getRevision() {
-        return revision;
-    }
-
-    public ConsumerStrategy getStrategy() {
-        return strategy;
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionSettingsBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionSettingsBuilder.java
@@ -1,140 +1,61 @@
 package com.eventstore.dbclient;
 
-import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
-
-public class PersistentSubscriptionSettingsBuilder {
-    private int checkpointAfterMs;
-    private boolean extraStatistics;
-    private boolean resolveLinks;
-    private int historyBufferSize;
-    private int liveBufferSize;
-    private int maxCheckpointCount;
-    private int maxRetryCount;
-    private int maxSubscriberCount;
-    private int messageTimeoutMs;
-    private int minCheckpointCount;
-    private int readBatchSize;
-    private long revision;
-    private ConsumerStrategy strategy;
+public class PersistentSubscriptionSettingsBuilder
+        extends AbstractPersistentSubscriptionSettingsBuilder<PersistentSubscriptionSettingsBuilder> {
+    protected StreamRevision revision;
 
     public PersistentSubscriptionSettingsBuilder() {
-        checkpointAfterMs = 2_000;
-        resolveLinks = false;
-        extraStatistics = false;
-        revision = 0;
-        messageTimeoutMs = 30_000;
-        maxRetryCount = 10;
-        minCheckpointCount = 10;
-        maxCheckpointCount = 1_000;
-        maxSubscriberCount = 0;
-        liveBufferSize = 500;
-        readBatchSize = 20;
-        historyBufferSize = 500;
-        strategy = ConsumerStrategy.RoundRobin;
+        revision = StreamRevision.END;
     }
 
     public PersistentSubscriptionSettingsBuilder(PersistentSubscriptionSettings settings) {
-        checkpointAfterMs = settings.getCheckpointAfterMs();
-        resolveLinks = settings.isResolveLinks();
-        extraStatistics = settings.isExtraStatistics();
-        revision = settings.getRevision();
-        messageTimeoutMs = settings.getMessageTimeoutMs();
-        maxRetryCount = settings.getMaxRetryCount();
-        minCheckpointCount = settings.getMinCheckpointCount();
-        maxCheckpointCount = settings.getMaxCheckpointCount();
-        maxSubscriberCount = settings.getMaxSubscriberCount();
-        liveBufferSize = settings.getLiveBufferSize();
-        readBatchSize = settings.getReadBatchSize();
-        historyBufferSize = settings.getHistoryBufferSize();
-        strategy = settings.getStrategy();
+        super(settings);
+
+        revision = settings.getStreamRevision();
     }
 
     public PersistentSubscriptionSettings build() {
-        return new PersistentSubscriptionSettings(checkpointAfterMs, extraStatistics, resolveLinks, historyBufferSize, liveBufferSize, maxCheckpointCount, maxRetryCount, maxSubscriberCount, messageTimeoutMs, minCheckpointCount, readBatchSize, revision, strategy);
+        return new PersistentSubscriptionSettings(checkpointAfterMs, extraStatistics, resolveLinkTos, historyBufferSize,
+                liveBufferSize, checkPointUpperBound, maxRetryCount, maxSubscriberCount, messageTimeoutMs,
+                checkPointLowerBound, readBatchSize, revision, consumerStrategyName);
     }
 
-    public PersistentSubscriptionSettingsBuilder enableLinkResolution() {
-        return resolveLinks(true);
+    public PersistentSubscriptionSettingsBuilder fromStart() {
+        return this.startFrom(StreamRevision.START);
     }
 
-    public PersistentSubscriptionSettingsBuilder disableLinkResolution() {
-        return resolveLinks(false);
+    public PersistentSubscriptionSettingsBuilder fromEnd() {
+        return this.startFrom(StreamRevision.END);
     }
 
-    public PersistentSubscriptionSettingsBuilder resolveLinks(boolean value) {
-        this.resolveLinks = value;
-        return this;
+    /**
+     * The exclusive position in the stream or transaction file the subscription should start from. Default: End of stream.
+     */
+    public PersistentSubscriptionSettingsBuilder startFrom(long value) {
+        return this.startFrom(new StreamRevision(value));
     }
 
-    public PersistentSubscriptionSettingsBuilder enableExtraStatistics() {
-        return extraStatistics(true);
-    }
-
-    public PersistentSubscriptionSettingsBuilder disableExtraStatistics() {
-        return extraStatistics(false);
-    }
-
-    public PersistentSubscriptionSettingsBuilder extraStatistics(boolean value) {
-        this.extraStatistics = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder checkpointAfterInMs(int value) {
-        this.checkpointAfterMs = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder revision(long value) {
+    /**
+     * The exclusive position in the stream or transaction file the subscription should start from. Default: End of stream.
+     */
+    public PersistentSubscriptionSettingsBuilder startFrom(StreamRevision value) {
         this.revision = value;
         return this;
     }
 
+    /**
+     * @deprecated prefer {@link #startFrom(long)}
+     */
+    @Deprecated
+    public PersistentSubscriptionSettingsBuilder revision(long value) {
+        return this.startFrom(value);
+    }
+
+    /**
+     * @deprecated prefer {@link #fromStart()}
+     */
+    @Deprecated
     public PersistentSubscriptionSettingsBuilder fromStreamStart() {
-        return revision(0);
-    }
-
-    public PersistentSubscriptionSettingsBuilder historyBufferSize(int value) {
-        this.historyBufferSize = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder liveBufferSize(int value) {
-        this.liveBufferSize = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder maxCheckpointCount(int value) {
-        this.maxCheckpointCount = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder minCheckpointCount(int value) {
-        this.minCheckpointCount = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder maxSubscriberCount(int value) {
-        this.maxSubscriberCount = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder maxRetryCount(int value) {
-        this.maxRetryCount = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder messageTimeoutInMs(int value) {
-        this.messageTimeoutMs = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder readBatchSize(int value) {
-        this.readBatchSize = value;
-        return this;
-    }
-
-    public PersistentSubscriptionSettingsBuilder consumerStrategy(ConsumerStrategy strategy) {
-        this.strategy = strategy;
-        return this;
+        return this.fromStart();
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionToAllSettings.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionToAllSettings.java
@@ -1,0 +1,28 @@
+package com.eventstore.dbclient;
+
+public class PersistentSubscriptionToAllSettings extends AbstractPersistentSubscriptionSettings {
+    private Position position;
+
+    public PersistentSubscriptionToAllSettings(int checkpointAfterMs, boolean extraStatistics, boolean resolveLinks,
+                                               int historyBufferSize, int liveBufferSize, int maxCheckpointCount,
+                                               int maxRetryCount, int maxSubscriberCount, int messageTimeoutMs,
+                                               int minCheckpointCount, int readBatchSize, String strategy,
+                                               Position position) {
+        super(checkpointAfterMs, extraStatistics, resolveLinks, historyBufferSize, liveBufferSize, maxCheckpointCount,
+                maxRetryCount, maxSubscriberCount, messageTimeoutMs, minCheckpointCount, readBatchSize, strategy);
+
+        this.position = position;
+    }
+
+    public Position getPosition() {
+        return position;
+    }
+
+    public static PersistentSubscriptionToAllSettingsBuilder builder() {
+        return new PersistentSubscriptionToAllSettingsBuilder();
+    }
+
+    public static PersistentSubscriptionToAllSettingsBuilder copy(PersistentSubscriptionToAllSettings settings) {
+        return new PersistentSubscriptionToAllSettingsBuilder(settings);
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionToAllSettingsBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionToAllSettingsBuilder.java
@@ -1,0 +1,45 @@
+package com.eventstore.dbclient;
+
+public class PersistentSubscriptionToAllSettingsBuilder
+        extends AbstractPersistentSubscriptionSettingsBuilder<PersistentSubscriptionToAllSettingsBuilder> {
+    private Position position;
+
+    public PersistentSubscriptionToAllSettingsBuilder() {
+        position = Position.END;
+    }
+
+    public PersistentSubscriptionToAllSettingsBuilder(PersistentSubscriptionToAllSettings settings) {
+        super(settings);
+
+        position = settings.getPosition();
+    }
+
+    public PersistentSubscriptionToAllSettings build() {
+        return new PersistentSubscriptionToAllSettings(checkpointAfterMs, extraStatistics, resolveLinkTos, historyBufferSize,
+                liveBufferSize, checkPointUpperBound, maxRetryCount, maxSubscriberCount, messageTimeoutMs,
+                checkPointLowerBound, readBatchSize, consumerStrategyName, position);
+    }
+
+    public PersistentSubscriptionToAllSettingsBuilder fromStart() {
+        return this.startFrom(Position.START);
+    }
+
+    public PersistentSubscriptionToAllSettingsBuilder fromEnd() {
+        return this.startFrom(Position.END);
+    }
+
+    /**
+     * The exclusive position in the stream or transaction file the subscription should start from. Default: End of stream.
+     */
+    public PersistentSubscriptionToAllSettingsBuilder startFrom(long commitUnsigned, long prepareUnsigned) {
+        return startFrom(new Position(commitUnsigned, prepareUnsigned));
+    }
+
+    /**
+     * The exclusive position in the stream or transaction file the subscription should start from. Default: End of stream.
+     */
+    public PersistentSubscriptionToAllSettingsBuilder startFrom(Position value) {
+        this.position = value;
+        return this;
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/SubscribePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/SubscribePersistentSubscription.java
@@ -1,122 +1,28 @@
 package com.eventstore.dbclient;
 
 import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
-import com.eventstore.dbclient.proto.persistentsubscriptions.PersistentSubscriptionsGrpc;
 import com.eventstore.dbclient.proto.shared.Shared;
 import com.google.protobuf.ByteString;
-import io.grpc.Metadata;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
-import io.grpc.stub.ClientCallStreamObserver;
-import io.grpc.stub.ClientResponseObserver;
-import io.grpc.stub.MetadataUtils;
-import io.grpc.stub.StreamObserver;
 
-import java.util.concurrent.CompletableFuture;
-
-public class SubscribePersistentSubscription {
-    private static final Persistent.ReadReq.Options.Builder defaultReadOptions;
-    private final GrpcClient connection;
+public class SubscribePersistentSubscription extends AbstractSubscribePersistentSubscription {
     private final String stream;
-    private final String group;
-    private final PersistentSubscriptionListener listener;
-    private final SubscribePersistentSubscriptionOptions options;
 
-    static {
-        defaultReadOptions = Persistent.ReadReq.Options.newBuilder()
-                .setUuidOption(Persistent.ReadReq.Options.UUIDOption.newBuilder()
-                        .setStructured(Shared.Empty.getDefaultInstance()));
-    }
+    public SubscribePersistentSubscription(GrpcClient connection, String stream, String group,
+                                           SubscribePersistentSubscriptionOptions options,
+                                           PersistentSubscriptionListener listener) {
+        super(connection, group, options, listener);
 
-    public SubscribePersistentSubscription(GrpcClient connection, String stream, String group, SubscribePersistentSubscriptionOptions options, PersistentSubscriptionListener listener) {
-        this.connection = connection;
         this.stream = stream;
-        this.group = group;
-        this.listener = listener;
-        this.options = options;
     }
 
-    public CompletableFuture execute() {
-        return this.connection.run(channel -> {
-            Metadata headers = this.options.getMetadata();
-            PersistentSubscriptionsGrpc.PersistentSubscriptionsStub client = MetadataUtils.attachHeaders(PersistentSubscriptionsGrpc.newStub(channel), headers);
+    @Override
+    protected Persistent.ReadReq.Options.Builder createOptions() {
+        Shared.StreamIdentifier streamIdentifier =
+                Shared.StreamIdentifier.newBuilder()
+                        .setStreamName(ByteString.copyFromUtf8(stream))
+                        .build();
 
-            final CompletableFuture<PersistentSubscription> result = new CompletableFuture<>();
-
-            Shared.StreamIdentifier streamIdentifier =
-                    Shared.StreamIdentifier.newBuilder()
-                            .setStreamName(ByteString.copyFromUtf8(stream))
-                            .build();
-
-            int bufferSize = this.options.getBufferSize();
-
-            Persistent.ReadReq.Options options = defaultReadOptions.clone()
-                    .setBufferSize(bufferSize)
-                    .setStreamIdentifier(streamIdentifier)
-                    .setGroupName(group)
-                    .build();
-
-            Persistent.ReadReq req = Persistent.ReadReq.newBuilder()
-                    .setOptions(options)
-                    .build();
-
-            ClientResponseObserver<Persistent.ReadReq, Persistent.ReadResp> observer = new ClientResponseObserver<Persistent.ReadReq, Persistent.ReadResp>() {
-                private boolean _confirmed;
-                private PersistentSubscription _subscription;
-                private ClientCallStreamObserver<Persistent.ReadReq> _requestStream;
-
-                @Override
-                public void beforeStart(ClientCallStreamObserver<Persistent.ReadReq> requestStream) {
-                    this._requestStream = requestStream;
-                }
-
-                @Override
-                public void onNext(Persistent.ReadResp readResp) {
-                    if (!_confirmed && readResp.hasSubscriptionConfirmation()) {
-                        this._confirmed = true;
-                        this._subscription = new PersistentSubscription(this._requestStream, readResp.getSubscriptionConfirmation().getSubscriptionId(), stream, group, bufferSize, defaultReadOptions);
-                        result.complete(this._subscription);
-                        return;
-                    }
-
-                    if (!_confirmed && readResp.hasEvent()) {
-                        onError(new IllegalStateException("Unconfirmed persistent subscription received event"));
-                        return;
-                    }
-
-                    if (_confirmed && !readResp.hasEvent()) {
-                        onError(new IllegalStateException(
-                                String.format("Confirmed persistent subscription %s received non-{event,checkpoint} variant",
-                                        _subscription.getSubscriptionId())));
-                        return;
-                    }
-
-                    listener.onEvent(this._subscription, ResolvedEvent.fromWire(readResp.getEvent()));
-                }
-
-                @Override
-                public void onError(Throwable t) {
-                    if (t instanceof StatusRuntimeException) {
-                        Status s = ((StatusRuntimeException) t).getStatus();
-                        if (s.getCode() == Status.Code.CANCELLED) {
-                            listener.onCancelled(this._subscription);
-                            return;
-                        }
-                    }
-
-                    listener.onError(this._subscription, t);
-                }
-
-                @Override
-                public void onCompleted() {
-                    // Subscriptions should only complete on error.
-                }
-            };
-
-            StreamObserver<Persistent.ReadReq> wireStream = client.read(observer);
-            wireStream.onNext(req);
-
-            return result;
-        });
+        return defaultReadOptions.clone()
+                .setStreamIdentifier(streamIdentifier);
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/SubscribePersistentSubscriptionToAll.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/SubscribePersistentSubscriptionToAll.java
@@ -1,0 +1,18 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
+import com.eventstore.dbclient.proto.shared.Shared;
+
+public class SubscribePersistentSubscriptionToAll extends AbstractSubscribePersistentSubscription {
+    public SubscribePersistentSubscriptionToAll(GrpcClient connection, String group,
+                                                SubscribePersistentSubscriptionOptions options,
+                                                PersistentSubscriptionListener listener) {
+        super(connection, group, options, listener);
+    }
+
+    @Override
+    protected Persistent.ReadReq.Options.Builder createOptions() {
+        return defaultReadOptions.clone()
+                .setAll(Shared.Empty.newBuilder());
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/SystemStreams.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/SystemStreams.java
@@ -1,0 +1,7 @@
+package com.eventstore.dbclient;
+
+public class SystemStreams {
+    public static final String ALL_STREAM = "$all";
+    public static final String STREAMS_STREAM = "$streams";
+    public static final String SETTINGS_STREAM = "$settings";
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/UpdatePersistentSubscriptionOptions.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/UpdatePersistentSubscriptionOptions.java
@@ -1,7 +1,9 @@
 package com.eventstore.dbclient;
 
-public class UpdatePersistentSubscriptionOptions extends ManagePersistentSubscriptionOptionsBase<UpdatePersistentSubscriptionOptions> {
-    private UpdatePersistentSubscriptionOptions() {
+public class UpdatePersistentSubscriptionOptions
+        extends ManagePersistentSubscriptionOptionsBase<UpdatePersistentSubscriptionOptions, PersistentSubscriptionSettings> {
+    protected UpdatePersistentSubscriptionOptions() {
+        super(PersistentSubscriptionSettings.builder().build());
     }
 
     public static UpdatePersistentSubscriptionOptions get() {

--- a/db-client-java/src/main/java/com/eventstore/dbclient/UpdatePersistentSubscriptionToAll.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/UpdatePersistentSubscriptionToAll.java
@@ -1,0 +1,36 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
+import com.eventstore.dbclient.proto.shared.Shared;
+
+public class UpdatePersistentSubscriptionToAll extends AbstractUpdatePersistentSubscription {
+    private final PersistentSubscriptionToAllSettings settings;
+
+    public UpdatePersistentSubscriptionToAll(GrpcClient connection, String group,
+                                             UpdatePersistentSubscriptionToAllOptions options) {
+        super(connection, group, options.getSettings(), options.getMetadata());
+
+        this.settings = options.getSettings();
+    }
+
+    @Override
+    protected Persistent.UpdateReq.Options.Builder createOptions() {
+        Persistent.UpdateReq.Options.Builder optionsBuilder = Persistent.UpdateReq.Options.newBuilder();
+        Persistent.UpdateReq.AllOptions.Builder allOptionsBuilder = Persistent.UpdateReq.AllOptions.newBuilder();
+
+        if (settings.getPosition() == Position.START) {
+            allOptionsBuilder.setStart(Shared.Empty.newBuilder());
+        } else if (settings.getPosition() == Position.END) {
+            allOptionsBuilder.setEnd(Shared.Empty.newBuilder());
+        } else {
+            Position position = settings.getPosition();
+            allOptionsBuilder.setPosition(Persistent.UpdateReq.Position.newBuilder()
+                    .setCommitPosition(position.getCommitUnsigned())
+                    .setPreparePosition(position.getPrepareUnsigned()));
+        }
+
+        optionsBuilder.setAll(allOptionsBuilder);
+
+        return optionsBuilder;
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/UpdatePersistentSubscriptionToAllOptions.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/UpdatePersistentSubscriptionToAllOptions.java
@@ -1,0 +1,12 @@
+package com.eventstore.dbclient;
+
+public class UpdatePersistentSubscriptionToAllOptions
+        extends ManagePersistentSubscriptionOptionsBase<UpdatePersistentSubscriptionToAllOptions, PersistentSubscriptionToAllSettings> {
+    protected UpdatePersistentSubscriptionToAllOptions() {
+        super(PersistentSubscriptionToAllSettings.builder().build());
+    }
+
+    public static UpdatePersistentSubscriptionToAllOptions get() {
+        return new UpdatePersistentSubscriptionToAllOptions();
+    }
+}

--- a/db-client-java/src/main/proto/persistent.proto
+++ b/db-client-java/src/main/proto/persistent.proto
@@ -19,7 +19,11 @@ message ReadReq {
 	}
 
 	message Options {
-		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		oneof stream_option {
+			event_store.client.shared.StreamIdentifier stream_identifier = 1;
+			event_store.client.shared.Empty all = 5;
+		}
+
 		string group_name = 2;
 		int32 buffer_size = 3;
 		UUIDOption uuid_option = 4;
@@ -89,14 +93,40 @@ message CreateReq {
 	Options options = 1;
 
 	message Options {
-		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		oneof stream_option {
+			StreamOptions stream = 4;
+			AllOptions all = 5;
+		}
+		event_store.client.shared.StreamIdentifier stream_identifier = 1 [deprecated=true];
 		string group_name = 2;
 		Settings settings = 3;
 	}
 
+	message StreamOptions {
+		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		oneof revision_option {
+			uint64 revision = 2;
+			event_store.client.shared.Empty start = 3;
+			event_store.client.shared.Empty end = 4;
+		}
+	}
+
+	message AllOptions {
+		oneof all_option {
+			Position position = 1;
+			event_store.client.shared.Empty start = 2;
+			event_store.client.shared.Empty end = 3;
+		}
+	}
+
+	message Position {
+		uint64 commit_position = 1;
+		uint64 prepare_position = 2;
+	}
+
 	message Settings {
 		bool resolve_links = 1;
-		uint64 revision = 2;
+		uint64 revision = 2 [deprecated = true];
 		bool extra_statistics = 3;
 		int32 max_retry_count = 5;
 		int32 min_checkpoint_count = 7;
@@ -130,14 +160,40 @@ message UpdateReq {
 	Options options = 1;
 
 	message Options {
-		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		oneof stream_option {
+			StreamOptions stream = 4;
+			AllOptions all = 5;
+		}
+		event_store.client.shared.StreamIdentifier stream_identifier = 1 [deprecated = true];
 		string group_name = 2;
 		Settings settings = 3;
 	}
 
+	message StreamOptions {
+		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		oneof revision_option {
+			uint64 revision = 2;
+			event_store.client.shared.Empty start = 3;
+			event_store.client.shared.Empty end = 4;
+		}
+	}
+
+	message AllOptions {
+		oneof all_option {
+			Position position = 1;
+			event_store.client.shared.Empty start = 2;
+			event_store.client.shared.Empty end = 3;
+		}
+	}
+
+	message Position {
+		uint64 commit_position = 1;
+		uint64 prepare_position = 2;
+	}
+
 	message Settings {
 		bool resolve_links = 1;
-		uint64 revision = 2;
+		uint64 revision = 2 [deprecated = true];
 		bool extra_statistics = 3;
 		int32 max_retry_count = 5;
 		int32 min_checkpoint_count = 7;
@@ -171,7 +227,10 @@ message DeleteReq {
 	Options options = 1;
 
 	message Options {
-		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		oneof stream_option {
+			event_store.client.shared.StreamIdentifier stream_identifier = 1;
+			event_store.client.shared.Empty all = 3;
+		}
 		string group_name = 2;
 	}
 }

--- a/db-client-java/src/test/java/com/eventstore/dbclient/CreatePersistentSubscriptionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/CreatePersistentSubscriptionTests.java
@@ -1,15 +1,25 @@
 package com.eventstore.dbclient;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import testcontainers.module.EventStoreTestDBContainer;
 
 public class CreatePersistentSubscriptionTests extends PersistenSubscriptionTestsBase {
     @Test
     public void testCreatePersistentSub() throws Throwable {
         client.create("aStream", "aGroup")
+                .get();
+
+        client.create("aStream", "bGroup", PersistentSubscriptionSettings.builder()
+                .revision(1).build())
+                .get();
+    }
+
+    @Test
+    public void testCreatePersistentSubToAll() throws Throwable {
+        client.createToAll("aGroup")
+                .get();
+
+        client.createToAll("bGroup", PersistentSubscriptionToAllSettings.builder()
+                .startFrom(2, 1).build())
                 .get();
     }
 }

--- a/db-client-java/src/test/java/com/eventstore/dbclient/DeletePersistentSubscriptionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/DeletePersistentSubscriptionTests.java
@@ -1,10 +1,6 @@
 package com.eventstore.dbclient;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import testcontainers.module.EventStoreTestDBContainer;
 
 public class DeletePersistentSubscriptionTests extends PersistenSubscriptionTestsBase {
     @Test
@@ -13,6 +9,15 @@ public class DeletePersistentSubscriptionTests extends PersistenSubscriptionTest
                 .get();
 
         client.delete("aStream", "aGroupUpd")
+                .get();
+    }
+
+    @Test
+    public void testDeletePersistentSubToAll() throws Throwable {
+        client.createToAll("aGroupUpd")
+                .get();
+
+        client.deleteToAll("aGroupUpd")
                 .get();
     }
 }

--- a/db-client-java/src/test/java/com/eventstore/dbclient/PersistenSubscriptionTestsBase.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/PersistenSubscriptionTestsBase.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ExecutionException;
 
 class PersistenSubscriptionTestsBase {
     @Rule
-    public final EventStoreTestDBContainer server = new EventStoreTestDBContainer(false);
+    public final EventStoreTestDBContainer server = new EventStoreTestDBContainer(true);
     protected EventStoreDBPersistentSubscriptionsClient client;
 
     @Before

--- a/db-client-java/src/test/java/com/eventstore/dbclient/SubscribePersistentSubcription.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/SubscribePersistentSubcription.java
@@ -82,4 +82,59 @@ public class SubscribePersistentSubcription extends PersistenSubscriptionTestsBa
 
         Assert.assertEquals(6, result.get().intValue());
     }
+
+    @Test
+    public void testSubscribePersistentSubToAll() throws Throwable {
+        EventStoreDBClient streamsClient = server.getClient();
+        String streamName = "aStream-" + UUID.randomUUID().toString();
+
+        client.createToAll("aGroup")
+                .get();
+
+        EventDataBuilder builder = EventData.builderAsJson("foobar", new SubscribePersistentSubcription.Foo());
+
+        streamsClient.appendToStream(streamName, builder.build(), builder.build(), builder.build())
+                .get();
+
+        final CompletableFuture<Integer> result = new CompletableFuture<>();
+
+        SubscribePersistentSubscriptionOptions connectOptions = SubscribePersistentSubscriptionOptions.get()
+                .setBufferSize(32);
+
+        client.subscribeToAll("aGroup", connectOptions, new PersistentSubscriptionListener() {
+            private int count = 0;
+
+            @Override
+            public void onEvent(PersistentSubscription subscription, ResolvedEvent resolvedEvent) {
+                RecordedEvent event = resolvedEvent.getEvent();
+
+                subscription.ack(resolvedEvent);
+
+                if (!event.getEventType().equals("foobar"))
+                    return;
+
+                ++this.count;
+
+                if (this.count == 6) {
+                    result.complete(this.count);
+                    subscription.stop();
+                }
+            }
+
+            @Override
+            public void onError(PersistentSubscription subscription, Throwable throwable) {
+                result.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onCancelled(PersistentSubscription subscription) {
+                result.complete(count);
+            }
+        }).get();
+
+        streamsClient.appendToStream(streamName, builder.build(), builder.build(), builder.build())
+                .get();
+
+        Assert.assertEquals(6, result.get().intValue());
+    }
 }

--- a/db-client-java/src/test/java/com/eventstore/dbclient/UpdatePersistentSubscriptionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/UpdatePersistentSubscriptionTests.java
@@ -11,12 +11,31 @@ public class UpdatePersistentSubscriptionTests extends PersistenSubscriptionTest
 
         PersistentSubscriptionSettings updatedSettings = PersistentSubscriptionSettings.builder()
                 .checkpointAfterInMs(5_000)
+                .revision(2)
                 .build();
 
         UpdatePersistentSubscriptionOptions options = UpdatePersistentSubscriptionOptions.get()
                 .settings(updatedSettings);
 
         client.update("aStream", "aGroupUpd", options)
-            .get();
+                .get();
+    }
+
+    @Test
+    public void testUpdatePersistentSubToAll() throws Throwable {
+
+        client.createToAll("aGroupUpd")
+                .get();
+
+        PersistentSubscriptionToAllSettings updatedSettings = PersistentSubscriptionToAllSettings.builder()
+                .checkpointAfterInMs(5_000)
+                .startFrom(4,3)
+                .build();
+
+        UpdatePersistentSubscriptionToAllOptions options = UpdatePersistentSubscriptionToAllOptions.get()
+                .settings(updatedSettings);
+
+        client.updateToAll("aGroupUpd", options)
+                .get();
     }
 }

--- a/db-client-java/src/test/java/com/eventstore/dbclient/samples/persistent_subscriptions/PersistentSubscriptions.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/samples/persistent_subscriptions/PersistentSubscriptions.java
@@ -1,0 +1,103 @@
+package com.eventstore.dbclient.samples.persistent_subscriptions;
+
+import com.eventstore.dbclient.*;
+
+public class PersistentSubscriptions {
+    public static void createPersistentSubscription(EventStoreDBPersistentSubscriptionsClient client) {
+        // region create-persistent-subscription-to-stream
+        client.create(
+            "test-stream",
+            "subscription-group",
+            PersistentSubscriptionSettings.builder()
+                .fromStart()
+                .build());
+        // region create-persistent-subscription-to-stream
+    }
+
+    public static void connectToPersistentSubscriptionToStream(EventStoreDBPersistentSubscriptionsClient client) {
+        // region subscribe-to-persistent-subscription-to-stream
+        client.subscribe(
+            "test-stream",
+            "subscription-group",
+            new PersistentSubscriptionListener() {
+                @Override
+                public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+                    System.out.println("Received event"
+                        + event.getOriginalEvent().getStreamRevision()
+                        + "@" + event.getOriginalEvent().getStreamId());
+                }
+
+                @Override
+                public void onError(PersistentSubscription subscription, Throwable throwable) {
+                    System.out.println("Subscription was dropped due to " + throwable.getMessage());
+                }
+
+                @Override
+                public void onCancelled(PersistentSubscription subscription) {
+                    System.out.println("Subscription is cancelled");
+                }
+            });
+        // region subscribe-to-persistent-subscription-to-stream
+    }
+
+    public static void createPersistentSubscriptionToAll(EventStoreDBPersistentSubscriptionsClient client) {
+        // region create-persistent-subscription-to-all
+        client.createToAll(
+            "subscription-group",
+            PersistentSubscriptionToAllSettings.builder()
+                .fromStart()
+                .build());
+        // region create-persistent-subscription-to-all
+    }
+
+    public static void connectToPersistentSubscriptionToAll(EventStoreDBPersistentSubscriptionsClient client) {
+        // region subscribe-to-persistent-subscription-to-all
+        client.subscribeToAll(
+            "subscription-group",
+            new PersistentSubscriptionListener() {
+                @Override
+                public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+                    try {
+                        System.out.println("Received event"
+                            + event.getOriginalEvent().getStreamRevision()
+                            + "@" + event.getOriginalEvent().getStreamId());
+                        subscription.ack(event);
+                    }
+                    catch (Exception ex) {
+                        subscription.nack(NackAction.Park, ex.getMessage(), event);
+                    }
+                }
+
+                @Override
+                public void onError(PersistentSubscription subscription, Throwable throwable) {
+                    System.out.println("Subscription was dropped due to " + throwable.getMessage());
+                }
+
+                @Override
+                public void onCancelled(PersistentSubscription subscription) {
+                    System.out.println("Subscription is cancelled");
+                }
+            });
+        // region subscribe-to-persistent-subscription-to-all
+    }
+
+    public static void updatePersistentSubscription(EventStoreDBPersistentSubscriptionsClient client) {
+        // region update-persistent-subscription-to-stream
+        client.update(
+            "test-stream",
+            "subscription-group",
+            PersistentSubscriptionSettings.builder()
+                .resolveLinkTos()
+                .checkPointLowerBound(20)
+                .build());
+        // region update-persistent-subscription-to-stream
+    }
+
+    public static void deletePersistentSubscription(EventStoreDBPersistentSubscriptionsClient client) {
+        // region delete-persistent-subscription-to-stream
+        client.delete(
+            "test-stream",
+            "subscription-group");
+        // region delete-persistent-subscription-to-stream
+    }
+}

--- a/db-client-java/src/test/java/testcontainers/module/EventStoreTestDBContainer.java
+++ b/db-client-java/src/test/java/testcontainers/module/EventStoreTestDBContainer.java
@@ -17,7 +17,7 @@ public class EventStoreTestDBContainer extends GenericContainer<EventStoreTestDB
     static {
         NAME = "eventstore-client-grpc-testdata";
         IMAGE = "docker.pkg.github.com/eventstore/eventstore-client-grpc-testdata/" + NAME;
-        IMAGE_TAG = "20.6.1-buster-slim";
+        IMAGE_TAG = "21.6.0-buster-slim";
         HEALTH_CHECK = new HealthCheck()
                 .withInterval(1000000000L)
                 .withTimeout(1000000000L)


### PR DESCRIPTION
Adds: Support for subscribing to persistent subscriptions to $all
Fixes: Persistent streams to start from the end by default.

**Breaking:** As defined by the _Persistent Subscriptions RFC_, the initial value for a persistent stream has been changed to start from the `end`.