### PR TITLE
Add type information to CompletableFuture in EventStoreDBPersistentSubscriptionsClient

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
@@ -37,7 +37,7 @@ public abstract class AbstractSubscribePersistentSubscription {
 
     protected abstract Persistent.ReadReq.Options.Builder createOptions();
 
-    public CompletableFuture execute() {
+    public CompletableFuture<PersistentSubscription> execute() {
         return this.connection.run(channel -> {
             Metadata headers = this.options.getMetadata();
             PersistentSubscriptionsGrpc.PersistentSubscriptionsStub client = MetadataUtils

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBPersistentSubscriptionsClient.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBPersistentSubscriptionsClient.java
@@ -134,15 +134,15 @@ public class EventStoreDBPersistentSubscriptionsClient extends EventStoreDBClien
         return new DeletePersistentSubscriptionToAll(this.client, group, options).execute();
     }
 
-    public CompletableFuture subscribe(String stream, String group, PersistentSubscriptionListener listener) {
+    public CompletableFuture<PersistentSubscription> subscribe(String stream, String group, PersistentSubscriptionListener listener) {
         return this.subscribe(stream, group, listener);
     }
 
-    public CompletableFuture subscribeToAll(String group, PersistentSubscriptionListener listener) {
+    public CompletableFuture<PersistentSubscription> subscribeToAll(String group, PersistentSubscriptionListener listener) {
         return this.subscribeToAll(group, SubscribePersistentSubscriptionOptions.get(), listener);
     }
 
-    public CompletableFuture subscribe(String stream, String group, SubscribePersistentSubscriptionOptions options, PersistentSubscriptionListener listener) {
+    public CompletableFuture<PersistentSubscription> subscribe(String stream, String group, SubscribePersistentSubscriptionOptions options, PersistentSubscriptionListener listener) {
         if (options == null) {
             options = SubscribePersistentSubscriptionOptions.get();
         }
@@ -153,7 +153,7 @@ public class EventStoreDBPersistentSubscriptionsClient extends EventStoreDBClien
 
         return new SubscribePersistentSubscription(this.client, stream, group, options, listener).execute();    }
 
-    public CompletableFuture subscribeToAll(String group, SubscribePersistentSubscriptionOptions options, PersistentSubscriptionListener listener) {
+    public CompletableFuture<PersistentSubscription> subscribeToAll(String group, SubscribePersistentSubscriptionOptions options, PersistentSubscriptionListener listener) {
         if (options == null) {
             options = SubscribePersistentSubscriptionOptions.get();
         }


### PR DESCRIPTION
Add type information to `CompletableFuture` for subscribing to a persistent subscription in the `EventStoreDBPersistentSubscriptionsClient`. 

Unifies the API for subscribing to streams between regular subscriptions and persistent subscriptions and is needed to properly control the lifecycle of the `PersistentSubscription`, i.e. cancelling the subscription, acknowledgement etc.