### PR TITLE
Improve handling of errors on subscribing to streams and persistent subscriptions.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRegularSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRegularSubscription.java
@@ -96,6 +96,10 @@ public abstract class AbstractRegularSubscription {
 
                 @Override
                 public void onError(Throwable throwable) {
+                    if (!_confirmed) {
+                        future.completeExceptionally(throwable);
+                    }
+
                     Throwable error = throwable;
                     if (error instanceof StatusRuntimeException) {
                         StatusRuntimeException sre = (StatusRuntimeException) error;

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
@@ -90,6 +90,10 @@ public abstract class AbstractSubscribePersistentSubscription {
 
                 @Override
                 public void onError(Throwable throwable) {
+                    if (!_confirmed) {
+                        result.completeExceptionally(throwable);
+                    }
+
                     Throwable error = throwable;
                     if (error instanceof StatusRuntimeException) {
                         StatusRuntimeException sre = (StatusRuntimeException) error;


### PR DESCRIPTION
Improve handling of errors on subscribing to streams and persistent subscrptions.

Currently gRPC excpetions on subscribe do not complete the future which will result in infinite runtime of future. A client waiting for the subscription will block unnecessarily and run into timeout exception instead of the exception thrown by subscribing. 

This pull request changes the behavior, that exceptions occuring before the subscription being confirmed will complete the future exceptionally. 