### PR TITLE
Add equals() and hashCode() to SpecificExpectedRevision

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ExpectedRevision.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ExpectedRevision.java
@@ -17,6 +17,17 @@ public abstract class ExpectedRevision {
     abstract public StreamsOuterClass.DeleteReq.Options.Builder applyOnWire(StreamsOuterClass.DeleteReq.Options.Builder options);
     abstract public StreamsOuterClass.TombstoneReq.Options.Builder applyOnWire(StreamsOuterClass.TombstoneReq.Options.Builder options);
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClass());
+    }
+
     static class NoStreamExpectedRevision extends ExpectedRevision {
         @Override
         public StreamsOuterClass.AppendReq.Options.Builder applyOnWire(StreamsOuterClass.AppendReq.Options.Builder options) {

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ExpectedRevision.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ExpectedRevision.java
@@ -3,6 +3,8 @@ package com.eventstore.dbclient;
 import com.eventstore.dbclient.proto.shared.Shared;
 import com.eventstore.dbclient.proto.streams.StreamsOuterClass;
 
+import java.util.Objects;
+
 public abstract class ExpectedRevision {
     public final static ExpectedRevision ANY = new AnyExpectedRevision();
     public final static ExpectedRevision NO_STREAM = new NoStreamExpectedRevision();
@@ -71,6 +73,19 @@ public abstract class ExpectedRevision {
 
         SpecificExpectedRevision(long version) {
             this.version = version;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SpecificExpectedRevision that = (SpecificExpectedRevision) o;
+            return version == that.version;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(version);
         }
 
         @Override

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ExpectedRevisionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ExpectedRevisionTests.java
@@ -3,16 +3,33 @@ package com.eventstore.dbclient;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class ExpectedRevisionTests {
 
     @Test
-    public void testSpecificExpectedRevisionEquality() {
+    public void testExpectedRevisionEquality() {
+        assertEquals(ExpectedRevision.ANY, new ExpectedRevision.AnyExpectedRevision());
+        assertEquals(ExpectedRevision.NO_STREAM, new ExpectedRevision.NoStreamExpectedRevision());
+        assertEquals(ExpectedRevision.STREAM_EXISTS, new ExpectedRevision.StreamExistsExpectedRevision());
         assertEquals(ExpectedRevision.expectedRevision(1L), ExpectedRevision.expectedRevision(1L));
     }
 
     @Test
-    public void testSpecificExpectedRevisionHashCode() {
+    public void testExpectedRevisionNonEquality() {
+        assertNotEquals(ExpectedRevision.ANY, ExpectedRevision.NO_STREAM);
+        assertNotEquals(ExpectedRevision.ANY, ExpectedRevision.STREAM_EXISTS);
+        assertNotEquals(ExpectedRevision.ANY, ExpectedRevision.expectedRevision(0L));
+        assertNotEquals(ExpectedRevision.NO_STREAM, ExpectedRevision.STREAM_EXISTS);
+        assertNotEquals(ExpectedRevision.NO_STREAM, ExpectedRevision.expectedRevision(0L));
+        assertNotEquals(ExpectedRevision.STREAM_EXISTS, ExpectedRevision.expectedRevision(0L));
+    }
+
+    @Test
+    public void testExpectedRevisionHashCode() {
+        assertEquals(ExpectedRevision.ANY.hashCode(), new ExpectedRevision.AnyExpectedRevision().hashCode());
+        assertEquals(ExpectedRevision.NO_STREAM.hashCode(), new ExpectedRevision.NoStreamExpectedRevision().hashCode());
+        assertEquals(ExpectedRevision.STREAM_EXISTS.hashCode(), new ExpectedRevision.StreamExistsExpectedRevision().hashCode());
         assertEquals(ExpectedRevision.expectedRevision(1L).hashCode(), ExpectedRevision.expectedRevision(1L).hashCode());
     }
 

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ExpectedRevisionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ExpectedRevisionTests.java
@@ -1,0 +1,19 @@
+package com.eventstore.dbclient;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExpectedRevisionTests {
+
+    @Test
+    public void testSpecificExpectedRevisionEquality() {
+        assertEquals(ExpectedRevision.expectedRevision(1L), ExpectedRevision.expectedRevision(1L));
+    }
+
+    @Test
+    public void testSpecificExpectedRevisionHashCode() {
+        assertEquals(ExpectedRevision.expectedRevision(1L).hashCode(), ExpectedRevision.expectedRevision(1L).hashCode());
+    }
+
+}


### PR DESCRIPTION
Add `equals()` and `hashCode()` to SpecificExpectedRevision class to allow quality checks.

These methods are missing and therefore it is not possible to properly check the equality of two `ExpectedRevision` instances.
Adding proper `equals()` implementation is helpful for implementing logic and tests regarding the expected revisions.
