### PR TITLE
Improve node selection algorithm

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/NodeSelector.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/NodeSelector.java
@@ -1,0 +1,72 @@
+package com.eventstore.dbclient;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+
+class NodeSelector {
+
+    private static final Random random = new Random();
+    private static final Set<ClusterInfo.MemberState> invalidStates;
+    private static final Map<NodePreference,Comparator<ClusterInfo.Member>> memberComparators;
+
+    static {
+        invalidStates = new HashSet<ClusterInfo.MemberState>() {{
+            add(ClusterInfo.MemberState.MANAGER);
+            add(ClusterInfo.MemberState.SHUTTING_DOWN);
+            add(ClusterInfo.MemberState.SHUT_DOWN);
+            add(ClusterInfo.MemberState.UNKNOWN);
+            add(ClusterInfo.MemberState.INITIALIZING);
+            add(ClusterInfo.MemberState.RESIGNING_LEADER);
+            add(ClusterInfo.MemberState.PRE_LEADER);
+            add(ClusterInfo.MemberState.PRE_REPLICA);
+            add(ClusterInfo.MemberState.PRE_READ_ONLY_REPLICA);
+            add(ClusterInfo.MemberState.CLONE);
+            add(ClusterInfo.MemberState.DISCOVER_LEADER);
+        }};
+
+        memberComparators= new HashMap<NodePreference, Comparator<ClusterInfo.Member>>()  {{
+            put(NodePreference.LEADER, new MemberComparator(ClusterInfo.MemberState.LEADER));
+            put(NodePreference.FOLLOWER, new MemberComparator(ClusterInfo.MemberState.FOLLOWER));
+            put(NodePreference.READ_ONLY_REPLICA, new MemberComparator(ClusterInfo.MemberState.READ_ONLY_REPLICA));
+            put(NodePreference.RANDOM, ((o1, o2) -> random.nextBoolean() ? -1 : 1));
+        }};
+    }
+
+    private final Comparator<ClusterInfo.Member> memberComparator;
+
+    NodeSelector(NodePreference nodePreference) {
+        this.memberComparator = memberComparators.get(nodePreference);
+    }
+
+    Optional<ClusterInfo.Member> determineBestFitNode(ClusterInfo clusterInfo) {
+        return clusterInfo.getMembers()
+                .stream()
+                .filter(ClusterInfo.Member::isAlive)
+                .filter(m -> !invalidStates.contains(m.getState()))
+                .sorted(memberComparator)
+                .findFirst();
+    }
+
+    private static class MemberComparator implements Comparator<ClusterInfo.Member> {
+        private final ClusterInfo.MemberState preferredState;
+
+        private MemberComparator(ClusterInfo.MemberState preferredState) {
+            this.preferredState = preferredState;
+        }
+
+        @Override
+        public int compare(ClusterInfo.Member o1, ClusterInfo.Member o2) {
+            if (o1.getState().equals(preferredState) && o2.getState().equals(preferredState)) {
+                return random.nextBoolean() ? -1 : 0;
+            } else if  (o1.getState().equals(preferredState) && !o2.getState().equals(preferredState)) {
+                return -1;
+            }
+            return 1;
+        }
+    }
+}

--- a/db-client-java/src/test/java/com/eventstore/dbclient/NodeSelectorTest.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/NodeSelectorTest.java
@@ -1,0 +1,108 @@
+package com.eventstore.dbclient;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static java.util.Arrays.asList;
+import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.*;
+
+public class NodeSelectorTest {
+
+    private ClusterInfo.Member leader;
+    private ClusterInfo.Member follower1;
+    private ClusterInfo.Member follower2;
+    private ClusterInfo.Member replica1;
+    private ClusterInfo.Member replica2;
+
+    private ClusterInfo clusterInfo;
+
+    @Before
+    public void setUp() {
+        leader = new ClusterInfo.Member(randomUUID(), true, ClusterInfo.MemberState.LEADER, null);
+        follower1 = new ClusterInfo.Member(randomUUID(), true, ClusterInfo.MemberState.FOLLOWER, null);
+        follower2 = new ClusterInfo.Member(randomUUID(), true, ClusterInfo.MemberState.FOLLOWER, null);
+        replica1 = new ClusterInfo.Member(randomUUID(), true, ClusterInfo.MemberState.READ_ONLY_REPLICA, null);
+        replica2 = new ClusterInfo.Member(randomUUID(), true, ClusterInfo.MemberState.READ_ONLY_REPLICA, null);
+
+        clusterInfo = new ClusterInfo(asList(leader, follower1, follower2, replica1, replica2));
+    }
+
+    @Test
+    public void shouldReturnEmptyPreferredNodeIfNodesAreInValidStates() {
+        leader = new ClusterInfo.Member(randomUUID(), true, ClusterInfo.MemberState.RESIGNING_LEADER, null);
+        follower1 = new ClusterInfo.Member(randomUUID(), true, ClusterInfo.MemberState.DISCOVER_LEADER, null);
+        follower2 = new ClusterInfo.Member(randomUUID(), true, ClusterInfo.MemberState.DISCOVER_LEADER, null);
+        clusterInfo = new ClusterInfo(asList(leader, follower1, follower2));
+        NodeSelector sut = new NodeSelector(NodePreference.LEADER);
+
+        Optional<ClusterInfo.Member> selectedNode = sut.determineBestFitNode(clusterInfo);
+
+        assertFalse(selectedNode.isPresent());
+    }
+
+    @Test
+    public void shouldReturnEmptyPreferredNodeIfNodesAreNotAlive() {
+        leader = new ClusterInfo.Member(randomUUID(), false, ClusterInfo.MemberState.LEADER, null);
+        follower1 = new ClusterInfo.Member(randomUUID(), false, ClusterInfo.MemberState.FOLLOWER, null);
+        follower2 = new ClusterInfo.Member(randomUUID(), false, ClusterInfo.MemberState.FOLLOWER, null);
+        clusterInfo = new ClusterInfo(asList(leader, follower1, follower2));
+        NodeSelector sut = new NodeSelector(NodePreference.LEADER);
+
+        Optional<ClusterInfo.Member> selectedNode = sut.determineBestFitNode(clusterInfo);
+
+        assertFalse(selectedNode.isPresent());
+    }
+
+    @Test
+    public void shouldSelectLeaderNodeOnNodePreferenceLeader() {
+        NodeSelector sut = new NodeSelector(NodePreference.LEADER);
+
+        Set<UUID> members = performMultipleNodeSelectionsWithSelector(sut);
+
+        assertEquals(1, members.size());
+        assertTrue(members.contains(leader.getInstanceId()));
+    }
+
+    @Test
+    public void shouldRandomlySelectFollowerNodeOnNodePreferenceFollower() {
+        NodeSelector sut = new NodeSelector(NodePreference.FOLLOWER);
+
+        Set<UUID> members = performMultipleNodeSelectionsWithSelector(sut);
+
+        assertEquals(2, members.size());
+        assertTrue(members.containsAll(asList(follower1.getInstanceId(), follower2.getInstanceId())));
+    }
+
+    @Test
+    public void shouldRandomlySelectReadOnlyReplicaNodeOnNodePreferenceReadOnlyReplica() {
+        NodeSelector sut = new NodeSelector(NodePreference.READ_ONLY_REPLICA);
+
+        Set<UUID> members = performMultipleNodeSelectionsWithSelector(sut);
+
+        assertEquals(2, members.size());
+        assertTrue(members.containsAll(asList(replica1.getInstanceId(), replica2.getInstanceId())));
+    }
+
+    @Test
+    public void shouldRandomlySelectNodeOnNodePreferenceRandom() {
+        NodeSelector sut = new NodeSelector(NodePreference.RANDOM);
+
+        Set<UUID> members = performMultipleNodeSelectionsWithSelector(sut);
+
+        assertEquals(5, members.size());
+    }
+
+    private Set<UUID> performMultipleNodeSelectionsWithSelector(NodeSelector sut) {
+        return IntStream.range(0, 100)
+                .mapToObj(i -> sut.determineBestFitNode(clusterInfo).get())
+                .map(ClusterInfo.Member::getInstanceId)
+                .collect(toSet());
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/EventStore/EventStoreDB-Client-Java/issues/83

Currently the node selection strategy always produces stable result always prefering a single node of the specified category. Always the same follower or read-only replica is selected based on the `ClusterInfo` retrieved from the seed node.

Even the `NodePreference.RANDOM` currently will always result in the same node to be returned to the client if the `Member` in the `ClusterInfo` will not change.

This PR properly performs random selection of nodes in each category. It also extracts the algorithm of the node selection into dedicated class for better testability.