### PR TITLE
Implementation of reactive streaming API for read operations.

### DIFF
--- a/db-client-java/build.gradle
+++ b/db-client-java/build.gradle
@@ -30,6 +30,8 @@ configurations {
 }
 
 dependencies {
+    api "org.reactivestreams:reactive-streams:${reactiveStreamsApiVersion}"
+
     implementation "javax.annotation:javax.annotation-api:${annotationApiVersion}"
     implementation "javax.validation:validation-api:${validationApiVersion}"
 
@@ -43,8 +45,9 @@ dependencies {
 
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "org.slf4j:slf4j-nop:${slf4jNopVersion}"
+    testImplementation "io.reactivex.rxjava3:rxjava:3.1.2"
+    testImplementation "org.reactivestreams:reactive-streams-tck:${reactiveStreamsApiVersion}"
     testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
-
     testImplementation platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}")
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadSubscriber.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadSubscriber.java
@@ -1,0 +1,26 @@
+package com.eventstore.dbclient;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+abstract class ReadSubscriber implements Subscriber<ResolvedEvent> {
+
+    private Subscription subscription;
+
+    @Override
+    public final void onSubscribe(Subscription s) {
+        this.subscription = s;
+        request(Long.MAX_VALUE);
+    }
+
+    public final void request(long n) {
+        this.subscription.request(n);
+    }
+
+    @Override
+    public final void onNext(ResolvedEvent resolvedEvent) {
+        onEvent(resolvedEvent);
+    }
+
+    public abstract void onEvent(ResolvedEvent resolvedEvent);
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadSubscription.java
@@ -1,0 +1,85 @@
+package com.eventstore.dbclient;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+class ReadSubscription implements Subscription {
+    private final Subscriber<? super ResolvedEvent> subscriber;
+    private ClientCallStreamObserver<?> streamObserver;
+    private final AtomicLong requested = new AtomicLong(0);
+    private final AtomicBoolean terminated = new AtomicBoolean(false);
+    private final Lock lock = new ReentrantLock();
+    private final Condition hasRequested = lock.newCondition();
+
+    ReadSubscription(Subscriber<? super ResolvedEvent> subscriber) {
+        this.subscriber = subscriber;
+    }
+
+    public void setStreamObserver(ClientCallStreamObserver<?> streamObserver) {
+        this.streamObserver = streamObserver;
+    }
+
+    public void onStreamNotFound() {
+        subscriber.onError(new StreamNotFoundException());
+    }
+
+    public void onError(Throwable error) {
+        if (error instanceof StatusRuntimeException) {
+            StatusRuntimeException statusRuntimeException = (StatusRuntimeException) error;
+            if (statusRuntimeException.getStatus().getCode() == Status.Code.CANCELLED) {
+                return;
+            }
+        }
+        cancel();
+        subscriber.onError(error);
+    }
+
+    public void onNext(ResolvedEvent event) {
+        lock.lock();
+        while (requested.get() == 0 && !terminated.get()) {
+            hasRequested.awaitUninterruptibly();
+        }
+        if (!terminated.get()) {
+            subscriber.onNext(event);
+            requested.decrementAndGet();
+        }
+        lock.unlock();
+    }
+
+    public void onCompleted() {
+        if (!terminated.get()) {
+            subscriber.onComplete();
+        }
+        terminated.compareAndSet(false, true);
+    }
+
+    @Override
+    public void request(long n) {
+        if (n <= 0) {
+            subscriber.onError(new IllegalArgumentException("non-positive subscription request: " + n));
+        }
+        lock.lock();
+        requested.updateAndGet(current -> current + n);
+        hasRequested.signal();
+        lock.unlock();
+    }
+
+    @Override
+    public void cancel() {
+        if (terminated.compareAndSet(false, true)) {
+            if (streamObserver != null) {
+                streamObserver.cancel("Stream has been cancelled manually.", null);
+            }
+        }
+    }
+
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/RecordedEvent.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/RecordedEvent.java
@@ -9,6 +9,8 @@ import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.UUID;
 
 public class RecordedEvent {
@@ -110,6 +112,19 @@ public class RecordedEvent {
     @NotNull
     public String getContentType() {
         return contentType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RecordedEvent that = (RecordedEvent) o;
+        return streamId.equals(that.streamId) && streamRevision.equals(that.streamRevision) && eventId.equals(that.eventId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(streamId, streamRevision, eventId);
     }
 
     static RecordedEvent fromWire(StreamsOuterClass.ReadResp.ReadEvent.RecordedEvent wireEvent) {

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ResolvedEvent.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ResolvedEvent.java
@@ -3,6 +3,9 @@ package com.eventstore.dbclient;
 import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
 import com.eventstore.dbclient.proto.streams.StreamsOuterClass;
 
+import java.util.Objects;
+import java.util.StringJoiner;
+
 public class ResolvedEvent {
     private final RecordedEvent event;
     private final RecordedEvent link;
@@ -22,6 +25,19 @@ public class ResolvedEvent {
 
     public RecordedEvent getOriginalEvent() {
         return this.link != null ? this.link : this.event;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResolvedEvent that = (ResolvedEvent) o;
+        return event.equals(that.event) && Objects.equals(link, that.link);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(event, link);
     }
 
     static ResolvedEvent fromWire(StreamsOuterClass.ReadResp.ReadEvent wireEvent) {

--- a/db-client-java/src/test/java/com/eventstore/dbclient/EventCollectorReadSubscriber.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/EventCollectorReadSubscriber.java
@@ -1,0 +1,26 @@
+package com.eventstore.dbclient;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+public class EventCollectorReadSubscriber extends ReadSubscriber {
+    List<ResolvedEvent> events = new LinkedList<>();
+
+    public List<ResolvedEvent> getEvents() {
+        return Collections.unmodifiableList(events);
+    }
+
+    @Override
+    public void onEvent(ResolvedEvent resolvedEvent) {
+        events.add(resolvedEvent);
+    }
+
+    @Override
+    public void onError(Throwable error) {
+    }
+
+    @Override
+    public void onComplete() {
+    }
+}

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ReactiveStreamsPublisherVerificationTCK.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ReactiveStreamsPublisherVerificationTCK.java
@@ -1,0 +1,276 @@
+package com.eventstore.dbclient;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.SkipException;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertNotNull;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public abstract class ReactiveStreamsPublisherVerificationTCK<T> extends PublisherVerification<T> {
+
+    public ReactiveStreamsPublisherVerificationTCK(TestEnvironment env) {
+        super(env);
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        mapTestNgAssumptionViolations(super::setUp);
+    }
+
+    @Test
+    public void testAllTestNGTestsAreOverridden() {
+        for (Method method : ReactiveStreamsPublisherVerificationTCK.class.getMethods())
+            if (method.getAnnotation(org.testng.annotations.Test.class) != null)
+                assertNotNull("TestNG test must be annotated with junit @Test: " + method, method.getAnnotation(Test.class));
+    }
+
+    @Override
+    @Test
+    public void required_createPublisher1MustProduceAStreamOfExactly1Element() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_createPublisher1MustProduceAStreamOfExactly1Element);
+    }
+
+    @Override
+    @Test
+    public void required_createPublisher3MustProduceAStreamOfExactly3Elements() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_createPublisher3MustProduceAStreamOfExactly3Elements);
+    }
+
+    @Override
+    @Test
+    public void required_validate_maxElementsFromPublisher() throws Exception {
+        mapTestNgAssumptionViolations(super::required_validate_maxElementsFromPublisher);
+    }
+
+    @Override
+    @Test
+    public void required_validate_boundedDepthOfOnNextAndRequestRecursion() throws Exception {
+        mapTestNgAssumptionViolations(super::required_validate_boundedDepthOfOnNextAndRequestRecursion);
+    }
+
+    @Override
+    @Test
+    public void required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements);
+    }
+
+    @Override
+    @Test
+    public void required_spec102_maySignalLessThanRequestedAndTerminateSubscription() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec102_maySignalLessThanRequestedAndTerminateSubscription);
+    }
+
+    @Override
+    @Test
+    public void stochastic_spec103_mustSignalOnMethodsSequentially() throws Throwable {
+        mapTestNgAssumptionViolations(super::stochastic_spec103_mustSignalOnMethodsSequentially);
+    }
+
+    @Override
+    @Test
+    public void optional_spec104_mustSignalOnErrorWhenFails() throws Throwable {
+        mapTestNgAssumptionViolations(super::optional_spec104_mustSignalOnErrorWhenFails);
+    }
+
+    @Override
+    @Test
+    public void required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates);
+    }
+
+    @Override
+    @Test
+    public void optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() throws Throwable {
+        mapTestNgAssumptionViolations(super::optional_spec105_emptyStreamMustTerminateBySignallingOnComplete);
+    }
+
+    @Override
+    @Test
+    public void untested_spec106_mustConsiderSubscriptionCancelledAfterOnErrorOrOnCompleteHasBeenCalled() throws Throwable {
+        mapTestNgAssumptionViolations(super::untested_spec106_mustConsiderSubscriptionCancelledAfterOnErrorOrOnCompleteHasBeenCalled);
+    }
+
+    @Override
+    @Test
+    public void required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled);
+    }
+
+    @Override
+    @Test
+    public void untested_spec107_mustNotEmitFurtherSignalsOnceOnErrorHasBeenSignalled() throws Throwable {
+        mapTestNgAssumptionViolations(super::untested_spec107_mustNotEmitFurtherSignalsOnceOnErrorHasBeenSignalled);
+    }
+
+    @Override
+    @Test
+    public void untested_spec108_possiblyCanceledSubscriptionShouldNotReceiveOnErrorOrOnCompleteSignals() throws Throwable {
+        mapTestNgAssumptionViolations(super::untested_spec108_possiblyCanceledSubscriptionShouldNotReceiveOnErrorOrOnCompleteSignals);
+    }
+
+    @Override
+    @Test
+    public void untested_spec109_subscribeShouldNotThrowNonFatalThrowable() throws Throwable {
+        mapTestNgAssumptionViolations(super::untested_spec109_subscribeShouldNotThrowNonFatalThrowable);
+    }
+
+    @Override
+    @Test
+    public void required_spec109_subscribeThrowNPEOnNullSubscriber() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec109_subscribeThrowNPEOnNullSubscriber);
+    }
+
+    @Override
+    @Test
+    public void required_spec109_mustIssueOnSubscribeForNonNullSubscriber() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec109_mustIssueOnSubscribeForNonNullSubscriber);
+    }
+
+    @Override
+    @Test
+    public void required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe);
+    }
+
+    @Override
+    @Test
+    public void untested_spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice() throws Throwable {
+        mapTestNgAssumptionViolations(super::untested_spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice);
+    }
+
+    @Override
+    @Test
+    public void optional_spec111_maySupportMultiSubscribe() throws Throwable {
+        mapTestNgAssumptionViolations(super::optional_spec111_maySupportMultiSubscribe);
+    }
+
+    @Override
+    @Test
+    public void optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals() throws Throwable {
+        mapTestNgAssumptionViolations(super::optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals);
+    }
+
+    @Override
+    @Test
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne() throws Throwable {
+        mapTestNgAssumptionViolations(super::optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne);
+    }
+
+    @Override
+    @Test
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront() throws Throwable {
+        mapTestNgAssumptionViolations(super::optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront);
+    }
+
+    @Override
+    @Test
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected() throws Throwable {
+        mapTestNgAssumptionViolations(super::optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected);
+    }
+
+    @Override
+    @Test
+    public void required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe);
+    }
+
+    @Override
+    @Test
+    public void required_spec303_mustNotAllowUnboundedRecursion() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec303_mustNotAllowUnboundedRecursion);
+    }
+
+    @Override
+    @Test
+    public void untested_spec304_requestShouldNotPerformHeavyComputations() throws Exception {
+        mapTestNgAssumptionViolations(super::untested_spec304_requestShouldNotPerformHeavyComputations);
+    }
+
+    @Override
+    @Test
+    public void untested_spec305_cancelMustNotSynchronouslyPerformHeavyComputation() throws Exception {
+        mapTestNgAssumptionViolations(super::untested_spec305_cancelMustNotSynchronouslyPerformHeavyComputation);
+    }
+
+    @Override
+    @Test
+    public void required_spec306_afterSubscriptionIsCancelledRequestMustBeNops() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec306_afterSubscriptionIsCancelledRequestMustBeNops);
+    }
+
+    @Override
+    @Test
+    public void required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops);
+    }
+
+    @Override
+    @Test
+    public void required_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec309_requestZeroMustSignalIllegalArgumentException);
+    }
+
+    @Override
+    @Test
+    public void required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec309_requestNegativeNumberMustSignalIllegalArgumentException);
+    }
+
+    @Override
+    @Test
+    public void optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage() throws Throwable {
+        mapTestNgAssumptionViolations(super::optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage);
+    }
+
+    @Override
+    @Test
+    public void required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling);
+    }
+
+    @Override
+    @Test
+    public void required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber);
+    }
+
+    @Override
+    @Test
+    public void required_spec317_mustSupportAPendingElementCountUpToLongMaxValue() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec317_mustSupportAPendingElementCountUpToLongMaxValue);
+    }
+
+    @Override
+    @Test
+    public void required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue);
+    }
+
+    @Override
+    @Test
+    public void required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue() throws Throwable {
+        mapTestNgAssumptionViolations(super::required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue);
+    }
+
+    private static <T extends Throwable> void mapTestNgAssumptionViolations(ThrowingRunnable<T> runnable) throws T {
+        try {
+            runnable.run();
+        } catch (SkipException e) {
+            throw new AssumptionViolatedException(e.getMessage());
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable<T extends Throwable> {
+        void run() throws T;
+    }
+}

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ReadAllPublisherVerification.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ReadAllPublisherVerification.java
@@ -1,0 +1,46 @@
+package com.eventstore.dbclient;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import testcontainers.module.EventStoreTestDBContainer;
+
+public class ReadAllPublisherVerification extends ReactiveStreamsPublisherVerificationTCK<ResolvedEvent> {
+
+    @Rule
+    public final EventStoreTestDBContainer server = new EventStoreTestDBContainer(false);
+
+    private EventStoreDBClient client;
+
+    public ReadAllPublisherVerification() {
+        super(new TestEnvironment(2000, 500, true));
+    }
+
+    @Before
+    public void setUp() {
+        client = server.getClient();
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        client.shutdown();
+    }
+
+    @Override
+    public Publisher<ResolvedEvent> createPublisher(long elements) {
+
+        ReadAllOptions options = ReadAllOptions.get()
+                .forwards()
+                .fromStart()
+                .notResolveLinkTos();
+
+        return client.readAllReactive(elements, options);
+    }
+
+    @Override
+    public Publisher<ResolvedEvent> createFailedPublisher() {
+        return null;
+    }
+}

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ReadAllReactiveTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ReadAllReactiveTests.java
@@ -1,0 +1,92 @@
+package com.eventstore.dbclient;
+
+import io.reactivex.rxjava3.core.Flowable;
+import org.junit.Rule;
+import org.junit.Test;
+import testcontainers.module.EventStoreTestDBContainer;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.stream.Collectors.toList;
+
+public class ReadAllReactiveTests {
+    @Rule
+    public final EventStoreTestDBContainer server = new EventStoreTestDBContainer(false);
+
+    @Test
+    public void testReadAllEventsReactiveForwardFromZeroPosition() throws ExecutionException, InterruptedException {
+        EventStoreDBClient client = server.getClient();
+
+        ReadAllOptions options = ReadAllOptions.get()
+                .forwards()
+                .fromStart()
+                .notResolveLinkTos();
+
+        List<ResolvedEvent> events = Flowable.fromPublisher(client.readAllReactive(10, options))
+                .collect(toList())
+                .blockingGet();
+
+        verifyAgainstTestData(events, "all-e0-e10");
+    }
+
+    @Test
+    public void testReadAllEventsReactiveForwardFromNonZeroPosition() throws ExecutionException, InterruptedException {
+        EventStoreDBClient client = server.getClient();
+
+        ReadAllOptions options = ReadAllOptions.get()
+                .forwards()
+                .fromPosition(new Position(1788, 1788))
+                .notResolveLinkTos();
+
+        List<ResolvedEvent> events = Flowable.fromPublisher(client.readAllReactive(10, options))
+                .collect(toList())
+                .blockingGet();
+
+        verifyAgainstTestData(events, "all-c1788-p1788");
+    }
+
+    @Test
+    public void testReadAllEventsReactiveBackwardsFromZeroPosition() throws ExecutionException, InterruptedException {
+        EventStoreDBClient client = server.getClient();
+
+        ReadAllOptions options = ReadAllOptions.get()
+                .backwards()
+                .fromEnd()
+                .notResolveLinkTos();
+
+        List<ResolvedEvent> events = Flowable.fromPublisher(client.readAllReactive(10, options))
+                .collect(toList())
+                .blockingGet();
+
+        verifyAgainstTestData(events, "all-back-e0-e10");
+    }
+
+    @Test
+    public void testReadAllEventsReactiveBackwardsFromNonZeroPosition() throws ExecutionException, InterruptedException {
+        EventStoreDBClient client = server.getClient();
+
+        ReadAllOptions options = ReadAllOptions.get()
+                .backwards()
+                .fromPosition(new Position(3386, 3386))
+                .notResolveLinkTos();
+
+        List<ResolvedEvent> events = Flowable.fromPublisher(client.readAllReactive(10, options))
+                .collect(toList())
+                .blockingGet();
+
+        verifyAgainstTestData(events, "all-back-c3386-p3386");
+    }
+
+    private void verifyAgainstTestData(List<ResolvedEvent> actualEvents, String filenameStem) {
+        ResolvedEvent[] actualEventsArray = actualEvents.toArray(new ResolvedEvent[0]);
+
+        TestResolvedEvent[] expectedEvents = TestDataLoader.loadSerializedResolvedEvents(filenameStem);
+        for (int i = 0; i < expectedEvents.length; i++) {
+            TestResolvedEvent expected = expectedEvents[i];
+            ResolvedEvent actual = actualEventsArray[i];
+
+            expected.assertEquals(actual);
+        }
+    }
+}

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ReadStreamPublisherVerification.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ReadStreamPublisherVerification.java
@@ -1,0 +1,47 @@
+package com.eventstore.dbclient;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import testcontainers.module.EventStoreTestDBContainer;
+
+public class ReadStreamPublisherVerification extends ReactiveStreamsPublisherVerificationTCK<ResolvedEvent> {
+
+    @Rule
+    public final EventStoreTestDBContainer server = new EventStoreTestDBContainer(false);
+
+    private EventStoreDBClient client;
+
+    public ReadStreamPublisherVerification() {
+        super(new TestEnvironment(2000, 500, true));
+    }
+
+    @Before
+    public void setUp() {
+        client = server.getClient();
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        client.shutdown();
+    }
+
+    @Override
+    public Publisher<ResolvedEvent> createPublisher(long elements) {
+
+        ReadStreamOptions options = ReadStreamOptions.get()
+                .forwards()
+                .fromStart()
+                .notResolveLinkTos();
+
+        return client.readStreamReactive("dataset20M-1800", elements, options);
+    }
+
+    @Override
+    public Publisher<ResolvedEvent> createFailedPublisher() {
+
+        return client.readStreamReactive("unknown-stream");
+    }
+}

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ReadStreamReactiveTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ReadStreamReactiveTests.java
@@ -1,0 +1,84 @@
+package com.eventstore.dbclient;
+
+import io.reactivex.rxjava3.core.Flowable;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import testcontainers.module.EventStoreTestDBContainer;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class ReadStreamReactiveTests {
+    @Rule
+    public final EventStoreTestDBContainer server = new EventStoreTestDBContainer(false);
+
+    @Test
+    public void testReadStreamReactiveForward10EventsFromPositionStart() throws Throwable {
+        EventStoreDBClient client = server.getClient();
+
+        ReadStreamOptions options = ReadStreamOptions.get()
+                .forwards()
+                .fromStart()
+                .notResolveLinkTos();
+
+        List<ResolvedEvent> events = Flowable.fromPublisher(client.readStreamReactive("dataset20M-1800", 10, options))
+                .collect(toList())
+                .blockingGet();
+
+        verifyAgainstTestData(events, "dataset20M-1800-e0-e10");
+    }
+
+    @Test
+    public void testReadStreamReactiveBackward10EventsFromPositionEnd() throws Throwable {
+        EventStoreDBClient client = server.getClient();
+
+        ReadStreamOptions options = ReadStreamOptions.get()
+                .backwards()
+                .fromEnd()
+                .notResolveLinkTos();
+
+        List<ResolvedEvent> events = Flowable.fromPublisher(client.readStreamReactive("dataset20M-1800", 10, options))
+                .collect(toList())
+                .blockingGet();
+
+        verifyAgainstTestData(events, "dataset20M-1800-e1999-e1990");
+    }
+
+    @Test
+    public void testReadStreamOptionsAreNotIgnoredInOverloadedMethod() throws Throwable {
+        EventStoreDBClient client = server.getClient();
+
+        ReadStreamOptions options = ReadStreamOptions.get()
+                .backwards()
+                .fromEnd()
+                .notResolveLinkTos();
+
+        List<ResolvedEvent> events1 = Flowable.fromPublisher(client.readStreamReactive("dataset20M-1800", Long.MAX_VALUE, options))
+                .collect(toList())
+                .blockingGet();
+
+        List<ResolvedEvent> events2 = Flowable.fromPublisher(client.readStreamReactive("dataset20M-1800", options))
+                .collect(toList())
+                .blockingGet();
+
+        RecordedEvent firstEvent1 = events1.get(0).getOriginalEvent();
+        RecordedEvent firstEvent2 = events2.get(0).getOriginalEvent();
+
+        Assert.assertEquals(events1.size(), events2.size());
+        Assert.assertEquals(firstEvent1.getEventId(), firstEvent2.getEventId());
+    }
+
+    private void verifyAgainstTestData(List<ResolvedEvent> actualEvents, String filenameStem) {
+        ResolvedEvent[] actualEventsArray = actualEvents.toArray(new ResolvedEvent[0]);
+
+        TestResolvedEvent[] expectedEvents = TestDataLoader.loadSerializedResolvedEvents(filenameStem);
+        for (int i = 0; i < expectedEvents.length; i++) {
+            TestResolvedEvent expected = expectedEvents[i];
+            ResolvedEvent actual = actualEventsArray[i];
+
+            expected.assertEquals(actual);
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ grpcVersion=1.31.1
 protobufVersion=3.12.2
 annotationApiVersion=1.3.2
 validationApiVersion=2.0.1.Final
+reactiveStreamsApiVersion=1.0.3
 
 # Test Dependencies
 junitVersion=4.13


### PR DESCRIPTION
This would a suggestion on implementing the streaming of read operations based on the reactive streams API supporting full backpressure and out-of-the-box compatibility with reative frameworks like RxJava, Project Reactor and JDK 9 Flow.

This solution consists of the following parts:
- Adaption of the EventStoreDBClient-API to return a (cold) `Publisher` of events on read operations. This is implemented by the `AbstractRead` (and its sub classes implementing the `Publisher` contract using the internal `ReadSubscription` class for fulfilling the reactive contract.
- Introduction of reactive streams TCK as test suite for testing the read operations and the reactive contract. 

The major building block is definetly the `ReadSubscription` class which acts as the adapter between the gRPC `StreamObserver`-API and the `Publisher` / `Subscriber` contract. This implementation is currently based on thread synchronisation between the gRPC reader thread used for triggering the `StreamObserver` and the `Subscribers` consumer thread which can be any thread including the main thread.