### PR TITLE
Increase default append size limit.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/AppendToStream.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AppendToStream.java
@@ -4,6 +4,7 @@ import com.eventstore.dbclient.proto.shared.Shared;
 import com.eventstore.dbclient.proto.streams.StreamsGrpc;
 import com.eventstore.dbclient.proto.streams.StreamsOuterClass;
 import com.google.protobuf.ByteString;
+import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.MetadataUtils;
@@ -38,7 +39,8 @@ public class AppendToStream {
                     .setStreamIdentifier(Shared.StreamIdentifier.newBuilder()
                             .setStreamName(ByteString.copyFromUtf8(streamName))
                             .build()));
-            StreamsGrpc.StreamsStub client = MetadataUtils.attachHeaders(StreamsGrpc.newStub(channel), headers);
+
+            StreamsGrpc.StreamsStub client = MetadataUtils.attachHeaders(StreamsGrpc.newStub(channel).withMaxOutboundMessageSize(16 * 1024 * 1024).withMaxInboundMessageSize(16 * 1024 * 1024), headers);
 
             StreamObserver<StreamsOuterClass.AppendReq> requestStream = client.append(GrpcUtils.convertSingleResponse(result, resp -> {
                 if (resp.hasSuccess()) {

--- a/db-client-java/src/main/java/com/eventstore/dbclient/GrpcClient.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/GrpcClient.java
@@ -260,7 +260,12 @@ public abstract class GrpcClient {
 
     protected ManagedChannel createChannel(Endpoint endpoint) {
         NettyChannelBuilder builder = NettyChannelBuilder
-                .forAddress(endpoint.getHostname(), endpoint.getPort());
+                .forAddress(endpoint.getHostname(), endpoint.getPort())
+                .maxInboundMessageSize(16 * 1024 * 1024)
+                .maxInboundMetadataSize(16 * 1024 * 1024)
+                .flowControlWindow(16 * 1024 * 1024)
+                .initialFlowControlWindow(16 * 1024 * 1024)
+                .perRpcBufferLimit(16 * 1024 * 1024);
 
         if (this.sslContext == null) {
             builder.usePlaintext();

--- a/db-client-java/src/test/java/com/eventstore/dbclient/AppendTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/AppendTests.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import testcontainers.module.EventStoreTestDBContainer;
 import testcontainers.module.EventStoreStreamsClient;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -83,5 +84,18 @@ public class AppendTests {
         assertEquals(eventId, first.getEventId().toString());
         assertArrayEquals(eventMetaData, first.getUserMetadata());
         assertEquals(new Foo(), first.getEventDataAs(Foo.class));
+    }
+
+    @Test
+    public void testMessageLimit() throws Throwable {
+        EventStoreDBClient client = server.getClient();
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < 16_000_000; i++) {
+            builder.append(' ');
+        }
+
+        EventData data = EventData.builderAsBinary("foobar", builder.toString().getBytes(StandardCharsets.UTF_8)).build();
+        client.appendToStream("abcdef", data).get();
     }
 }


### PR DESCRIPTION
Fixes #128 

The goal of this PR is to fix this specific error:
```
io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Maximum Append Size of 1048576 Exceeded.
java.util.concurrent.ExecutionException: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Maximum Append Size of 1048576 Exceeded.
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999)
```