### PR TITLE
Expose current stream positions and retry count when consuming a subscriptions

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRead.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRead.java
@@ -13,7 +13,7 @@ import org.reactivestreams.Subscriber;
 
 import java.util.concurrent.CompletableFuture;
 
-abstract class AbstractRead implements Publisher<ResolvedEvent> {
+abstract class AbstractRead implements Publisher<ReadMessage> {
     protected static final StreamsOuterClass.ReadReq.Options.Builder defaultReadOptions;
 
     private final GrpcClient client;
@@ -34,7 +34,7 @@ abstract class AbstractRead implements Publisher<ResolvedEvent> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void subscribe(Subscriber<? super ResolvedEvent> subscriber) {
+    public void subscribe(Subscriber<? super ReadMessage> subscriber) {
         ReadSubscription readSubscription = new ReadSubscription(subscriber);
         subscriber.onSubscribe(readSubscription);
 
@@ -61,13 +61,11 @@ abstract class AbstractRead implements Publisher<ResolvedEvent> {
                         return;
                     }
 
-                    if (value.hasEvent()) {
-                        try {
-                            readSubscription.onNext(ResolvedEvent.fromWire(value.getEvent()));
-                        } catch (Throwable t) {
-                            readSubscription.onError(t);
-                            this.completed = true;
-                        }
+                    try {
+                        readSubscription.onNext(new ReadMessage(value));
+                    } catch (Throwable t) {
+                        readSubscription.onError(t);
+                        this.completed = true;
                     }
                 }
 

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRegularSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRegularSubscription.java
@@ -8,7 +8,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
-import io.grpc.stub.MetadataUtils;
 
 import javax.validation.constraints.NotNull;
 import java.util.concurrent.CompletableFuture;
@@ -65,6 +64,7 @@ abstract class AbstractRegularSubscription {
                         this._subscription = new Subscription(this._requestStream,
                                 readResp.getConfirmation().getSubscriptionId(), checkpointer);
                         future.complete(this._subscription);
+                        listener.onConfirmation(this._subscription);
                         return;
                     }
 

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
@@ -73,6 +73,7 @@ abstract class AbstractSubscribePersistentSubscription {
                             this._subscription = new PersistentSubscription(this._requestStream,
                                     readResp.getSubscriptionConfirmation().getSubscriptionId());
                             result.complete(this._subscription);
+                            listener.onConfirmation(this._subscription);
                             return;
                         }
 
@@ -88,7 +89,9 @@ abstract class AbstractSubscribePersistentSubscription {
                             return;
                         }
 
-                        listener.onEvent(this._subscription, ResolvedEvent.fromWire(readResp.getEvent()));
+                        int retryCount = readResp.getEvent().hasNoRetryCount() ? 0 : readResp.getEvent().getRetryCount();
+
+                        listener.onEvent(this._subscription, retryCount, ResolvedEvent.fromWire(readResp.getEvent()));
                     }
 
                     @Override

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClient.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClient.java
@@ -1,6 +1,7 @@
 package com.eventstore.dbclient;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -8,6 +9,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 public class EventStoreDBClient extends EventStoreDBClientBase {
     private EventStoreDBClient(EventStoreDBClientSettings settings) {
@@ -63,22 +65,19 @@ public class EventStoreDBClient extends EventStoreDBClientBase {
     }
 
     public CompletableFuture<ReadResult> readStream(String streamName, long maxCount, ReadStreamOptions options) {
-        return readEventsFromPublisher(this.readStreamReactive(streamName, maxCount, options));
+        Publisher<ReadMessage> publisher = readStreamReactive(streamName, maxCount, options);
+        return readEventsFromPublisher(publisher);
     }
 
-    public Publisher<ResolvedEvent> readStreamReactive(String streamName) {
+    public Publisher<ReadMessage> readStreamReactive(String streamName) {
         return this.readStreamReactive(streamName, Long.MAX_VALUE, ReadStreamOptions.get());
     }
 
-    public Publisher<ResolvedEvent> readStreamReactive(String streamName, long maxCount) {
-        return this.readStreamReactive(streamName, maxCount, ReadStreamOptions.get());
-    }
-
-    public Publisher<ResolvedEvent> readStreamReactive(String streamName, ReadStreamOptions options) {
+    public Publisher<ReadMessage> readStreamReactive(String streamName, ReadStreamOptions options) {
         return this.readStreamReactive(streamName, Long.MAX_VALUE, options);
     }
 
-    public Publisher<ResolvedEvent> readStreamReactive(String streamName, long maxCount, ReadStreamOptions options) {
+    public Publisher<ReadMessage> readStreamReactive(String streamName, long maxCount, ReadStreamOptions options) {
         if (options == null)
             options = ReadStreamOptions.get();
 
@@ -86,6 +85,32 @@ public class EventStoreDBClient extends EventStoreDBClientBase {
             options.authenticated(this.credentials);
 
         return new ReadStream(this.client, streamName, maxCount, options);
+    }
+
+    private static <A, B> Publisher<B> publisherMap(final Publisher<A> parent, Function<A, B> fun) {
+        return sub -> {
+            parent.subscribe(new Subscriber<A>() {
+                @Override
+                public void onSubscribe(org.reactivestreams.Subscription s) {
+                    sub.onSubscribe(s);
+                }
+
+                @Override
+                public void onNext(A a) {
+                    sub.onNext(fun.apply(a));
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    sub.onError(t);
+                }
+
+                @Override
+                public void onComplete() {
+                    sub.onComplete();
+                }
+            });
+        };
     }
 
     public CompletableFuture<StreamMetadata> getStreamMetadata(String streamName) {
@@ -133,19 +158,19 @@ public class EventStoreDBClient extends EventStoreDBClientBase {
         return readEventsFromPublisher(this.readAllReactive(maxCount, options));
     }
 
-    public Publisher<ResolvedEvent> readAllReactive() {
+    public Publisher<ReadMessage> readAllReactive() {
         return this.readAllReactive(Long.MAX_VALUE, ReadAllOptions.get());
     }
 
-    public Publisher<ResolvedEvent> readAllReactive(long maxCount) {
+    public Publisher<ReadMessage> readAllReactive(long maxCount) {
         return this.readAllReactive(maxCount, ReadAllOptions.get());
     }
 
-    public Publisher<ResolvedEvent> readAllReactive(ReadAllOptions options) {
+    public Publisher<ReadMessage> readAllReactive(ReadAllOptions options) {
         return this.readAllReactive(Long.MAX_VALUE, options);
     }
 
-    public Publisher<ResolvedEvent> readAllReactive(long maxCount, ReadAllOptions options) {
+    public Publisher<ReadMessage> readAllReactive(long maxCount, ReadAllOptions options) {
         if (options == null)
             options = ReadAllOptions.get();
 
@@ -197,13 +222,34 @@ public class EventStoreDBClient extends EventStoreDBClientBase {
         return new DeleteStream(this.client, streamName, options).execute();
     }
 
-    private static CompletableFuture<ReadResult> readEventsFromPublisher(Publisher<ResolvedEvent> eventPublisher) {
+    private static CompletableFuture<ReadResult> readEventsFromPublisher(Publisher<ReadMessage> eventPublisher) {
         CompletableFuture<ReadResult> future = new CompletableFuture<>();
         List<ResolvedEvent> events = new LinkedList<>();
+
         eventPublisher.subscribe(new ReadSubscriber() {
+            long firstStreamPosition = 0;
+            long lastStreamPosition = 0;
+            Position lastAllStreamPosition = null;
+
             @Override
-            public void onEvent(ResolvedEvent resolvedEvent) {
-                events.add(resolvedEvent);
+            public void onEvent(ReadMessage e) {
+                if (e.hasFirstStreamPosition()) {
+                    firstStreamPosition = e.getFirstStreamPosition();
+                    return;
+                }
+
+                if (e.hasLastStreamPosition()) {
+                    lastStreamPosition = e.getLastStreamPosition();
+                    return;
+                }
+
+                if (e.hasLastAllPosition()) {
+                    lastAllStreamPosition = e.getLastAllPosition();
+                    return;
+                }
+
+                if (e.hasEvent())
+                    events.add(e.getEvent());
             }
 
             @Override
@@ -213,7 +259,7 @@ public class EventStoreDBClient extends EventStoreDBClientBase {
 
             @Override
             public void onComplete() {
-                future.complete(new ReadResult(events));
+                future.complete(new ReadResult(events, firstStreamPosition, lastStreamPosition, lastAllStreamPosition));
             }
         });
         return future;

--- a/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionListener.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/PersistentSubscriptionListener.java
@@ -1,12 +1,15 @@
 package com.eventstore.dbclient;
 
 public abstract class PersistentSubscriptionListener {
-    public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+    public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent event) {
     }
 
     public void onError(PersistentSubscription subscription, Throwable throwable) {
     }
 
     public void onCancelled(PersistentSubscription subscription) {
+    }
+
+    public void onConfirmation(PersistentSubscription subscription) {
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadAll.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadAll.java
@@ -32,6 +32,7 @@ class ReadAll extends AbstractRead {
         StreamsOuterClass.ReadReq.Options.Builder builder = defaultReadOptions.clone()
                 .setAll(optionsOrBuilder)
                 .setResolveLinks(this.options.shouldResolveLinkTos())
+                .setControlOption(StreamsOuterClass.ReadReq.Options.ControlOption.newBuilder().setCompatibility(1))
                 .setCount(this.maxCount)
                 .setNoFilter(Shared.Empty.getDefaultInstance())
                 .setReadDirection(this.options.getDirection() == Direction.Forwards ?

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadMessage.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadMessage.java
@@ -1,0 +1,93 @@
+package com.eventstore.dbclient;
+
+import com.eventstore.dbclient.proto.streams.StreamsOuterClass;
+
+/**
+ * Received when performing a regular read operation (not a subscription).
+ */
+public final class ReadMessage {
+    private Long firstStreamPosition;
+    private Long lastStreamPosition;
+    private Position lastAllPosition;
+    private ResolvedEvent event;
+
+    ReadMessage(StreamsOuterClass.ReadResp resp) {
+        if (resp.hasLastAllStreamPosition()) {
+            lastAllPosition = new Position(resp.getLastAllStreamPosition().getCommitPosition(), resp.getLastAllStreamPosition().getPreparePosition());
+            return;
+        }
+
+        if (resp.hasEvent()) {
+            event = ResolvedEvent.fromWire(resp.getEvent());
+            return;
+        }
+
+        if (resp.getLastStreamPosition() != 0) {
+            lastStreamPosition = resp.getLastStreamPosition();
+            return;
+        }
+
+        firstStreamPosition = resp.getFirstStreamPosition();
+    }
+
+    /**
+     * If this messages holds the first stream position.
+     */
+    public boolean hasFirstStreamPosition() {
+        return firstStreamPosition != null;
+    }
+
+    /**
+     * If this messages holds the last stream position.
+     */
+    public boolean hasLastStreamPosition() {
+        return lastStreamPosition != null;
+    }
+
+    /**
+     * If this messages holds the last $all position.
+     */
+    public boolean hasLastAllPosition() {
+        return lastAllPosition != null;
+    }
+
+    /**
+     * If this messages holds a resolved event.
+     */
+    public boolean hasEvent() {
+        return event != null;
+    }
+
+    /**
+     * Returns the first stream position if defined.
+     * @throws NullPointerException if not defined.
+     */
+    public long getFirstStreamPosition() {
+        return firstStreamPosition;
+    }
+
+    /**
+     * Returns the last stream position if defined.
+     * @throws NullPointerException if not defined.
+     */
+    public long getLastStreamPosition() {
+        return lastStreamPosition;
+    }
+
+    /**
+     * Returns the last $all position if defined.
+     * @return null is not defined.
+     */
+    public Position getLastAllPosition() {
+        return lastAllPosition;
+    }
+
+    /**
+     * Returns a resolved event if defined.
+     * @return null is not defined.
+     */
+    public ResolvedEvent getEvent() {
+        return event;
+    }
+}
+

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadResult.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadResult.java
@@ -4,12 +4,30 @@ import java.util.List;
 
 public class ReadResult {
     private final List<ResolvedEvent> events;
+    private final long firstStreamPosition;
+    private final long lastStreamPosition;
+    private final Position lastAllStreamPosition;
 
-    public ReadResult(List<ResolvedEvent> events) {
+    public ReadResult(List<ResolvedEvent> events, long firstStreamPosition, long lastStreamPosition, Position lastAllStreamPosition) {
         this.events = events;
+        this.firstStreamPosition = firstStreamPosition;
+        this.lastStreamPosition = lastStreamPosition;
+        this.lastAllStreamPosition = lastAllStreamPosition;
     }
 
     public List<ResolvedEvent> getEvents() {
         return this.events;
+    }
+
+    public long getFirstStreamPosition() {
+        return firstStreamPosition;
+    }
+
+    public long getLastStreamPosition() {
+        return lastStreamPosition;
+    }
+
+    public Position getLastAllStreamPosition() {
+        return lastAllStreamPosition;
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadStream.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadStream.java
@@ -26,6 +26,7 @@ class ReadStream extends AbstractRead {
                 .setStream(GrpcUtils.toStreamOptions(this.streamName, this.options.getStartingRevision()))
                 .setResolveLinks(this.options.shouldResolveLinkTos())
                 .setCount(this.maxCount)
+                .setControlOption(StreamsOuterClass.ReadReq.Options.ControlOption.newBuilder().setCompatibility(1))
                 .setNoFilter(Shared.Empty.getDefaultInstance())
                 .setReadDirection(this.options.getDirection() == Direction.Forwards ?
                         StreamsOuterClass.ReadReq.Options.ReadDirection.Forwards :

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadSubscriber.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadSubscriber.java
@@ -3,7 +3,7 @@ package com.eventstore.dbclient;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-abstract class ReadSubscriber implements Subscriber<ResolvedEvent> {
+abstract class ReadSubscriber implements Subscriber<ReadMessage> {
 
     private Subscription subscription;
 
@@ -18,9 +18,9 @@ abstract class ReadSubscriber implements Subscriber<ResolvedEvent> {
     }
 
     @Override
-    public final void onNext(ResolvedEvent resolvedEvent) {
+    public final void onNext(ReadMessage resolvedEvent) {
         onEvent(resolvedEvent);
     }
 
-    public abstract void onEvent(ResolvedEvent resolvedEvent);
+    public abstract void onEvent(ReadMessage resolvedEvent);
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ResolvedEvent.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ResolvedEvent.java
@@ -4,15 +4,19 @@ import com.eventstore.dbclient.proto.persistentsubscriptions.Persistent;
 import com.eventstore.dbclient.proto.streams.StreamsOuterClass;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 public class ResolvedEvent {
     private final RecordedEvent event;
     private final RecordedEvent link;
 
-    public ResolvedEvent(RecordedEvent event, RecordedEvent link) {
+    private final Position position;
+
+    public ResolvedEvent(RecordedEvent event, RecordedEvent link, Position position) {
         this.event = event;
         this.link = link;
+        this.position = position;
     }
 
     public RecordedEvent getEvent() {
@@ -25,6 +29,14 @@ public class ResolvedEvent {
 
     public RecordedEvent getOriginalEvent() {
         return this.link != null ? this.link : this.event;
+    }
+
+    /**
+     * Returns the transaction log position of the resolved event.
+     * @see Position
+     */
+    public Optional<Position> getPosition() {
+        return Optional.ofNullable(position);
     }
 
     @Override
@@ -43,14 +55,17 @@ public class ResolvedEvent {
     static ResolvedEvent fromWire(StreamsOuterClass.ReadResp.ReadEvent wireEvent) {
         RecordedEvent event = wireEvent.hasEvent() ? RecordedEvent.fromWire(wireEvent.getEvent()) : null;
         RecordedEvent link = wireEvent.hasLink() ? RecordedEvent.fromWire(wireEvent.getLink()) : null;
+        Position position = wireEvent.hasNoPosition() ? null : new Position(wireEvent.getCommitPosition(), wireEvent.getCommitPosition());
 
-        return new ResolvedEvent(event, link);
+        return new ResolvedEvent(event, link, position);
     }
 
     static ResolvedEvent fromWire(Persistent.ReadResp.ReadEvent wireEvent) {
         RecordedEvent event = wireEvent.hasEvent() ? RecordedEvent.fromWire(wireEvent.getEvent()) : null;
         RecordedEvent link = wireEvent.hasLink() ? RecordedEvent.fromWire(wireEvent.getLink()) : null;
+        Position position = wireEvent.hasNoPosition() ? null : new Position(wireEvent.getCommitPosition(), wireEvent.getCommitPosition());
 
-        return new ResolvedEvent(event, link);
+
+        return new ResolvedEvent(event, link, position);
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/SubscriptionListener.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/SubscriptionListener.java
@@ -9,4 +9,8 @@ public abstract class SubscriptionListener {
 
     public void onCancelled(Subscription subscription) {
     }
+
+    public void onConfirmation(Subscription subscription) {
+
+    }
 }

--- a/db-client-java/src/test/java/com/eventstore/dbclient/PersistentSubscriptionManagementTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/PersistentSubscriptionManagementTests.java
@@ -182,7 +182,7 @@ public class PersistentSubscriptionManagementTests extends ESDBTests {
         client.subscribeToStream(streamName, groupName, new PersistentSubscriptionListener() {
             int count = 0;
             @Override
-            public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+            public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent event) {
                 if (count < 2)
                     subscription.nack(NackAction.Park, "because reason", event);
                 else
@@ -262,7 +262,7 @@ public class PersistentSubscriptionManagementTests extends ESDBTests {
         client.subscribeToAll(groupName, new PersistentSubscriptionListener() {
             int count = 0;
             @Override
-            public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+            public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent event) {
                 if (count < 2 && event.getOriginalEvent().getStreamId().equals(streamName))
                     subscription.nack(NackAction.Park, "because reason", event);
                 else

--- a/db-client-java/src/test/java/com/eventstore/dbclient/PersistentSubscriptionToAllWithFilterTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/PersistentSubscriptionToAllWithFilterTests.java
@@ -30,7 +30,7 @@ public class PersistentSubscriptionToAllWithFilterTests extends ESDBTests {
             int current = 0;
 
             @Override
-            public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+            public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent event) {
                 RecordedEvent record = event.getEvent();
 
                 Assertions.assertEquals(filteredEventType, record.getEventType());

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ReadAllReactiveTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ReadAllReactiveTests.java
@@ -20,6 +20,8 @@ public class ReadAllReactiveTests extends ESDBTests {
                 .notResolveLinkTos();
 
         List<ResolvedEvent> events = Flowable.fromPublisher(client.readAllReactive(10, options))
+                .filter(ReadMessage::hasEvent)
+                .map(ReadMessage::getEvent)
                 .collect(toList())
                 .blockingGet();
 
@@ -36,6 +38,8 @@ public class ReadAllReactiveTests extends ESDBTests {
                 .notResolveLinkTos();
 
         List<ResolvedEvent> events = Flowable.fromPublisher(client.readAllReactive(10, options))
+                .filter(ReadMessage::hasEvent)
+                .map(ReadMessage::getEvent)
                 .collect(toList())
                 .blockingGet();
 
@@ -52,6 +56,8 @@ public class ReadAllReactiveTests extends ESDBTests {
                 .notResolveLinkTos();
 
         List<ResolvedEvent> events = Flowable.fromPublisher(client.readAllReactive(10, options))
+                .filter(ReadMessage::hasEvent)
+                .map(ReadMessage::getEvent)
                 .collect(toList())
                 .blockingGet();
 

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ReadStreamReactiveTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ReadStreamReactiveTests.java
@@ -20,6 +20,8 @@ public class ReadStreamReactiveTests extends ESDBTests {
                 .notResolveLinkTos();
 
         List<ResolvedEvent> events = Flowable.fromPublisher(client.readStreamReactive("dataset20M-1800", 10, options))
+                .filter(ReadMessage::hasEvent)
+                .map(ReadMessage::getEvent)
                 .collect(toList())
                 .blockingGet();
 
@@ -36,6 +38,8 @@ public class ReadStreamReactiveTests extends ESDBTests {
                 .notResolveLinkTos();
 
         List<ResolvedEvent> events = Flowable.fromPublisher(client.readStreamReactive("dataset20M-1800", 10, options))
+                .filter(ReadMessage::hasEvent)
+                .map(ReadMessage::getEvent)
                 .collect(toList())
                 .blockingGet();
 
@@ -52,10 +56,14 @@ public class ReadStreamReactiveTests extends ESDBTests {
                 .notResolveLinkTos();
 
         List<ResolvedEvent> events1 = Flowable.fromPublisher(client.readStreamReactive("dataset20M-1800", Long.MAX_VALUE, options))
+                .filter(ReadMessage::hasEvent)
+                .map(ReadMessage::getEvent)
                 .collect(toList())
                 .blockingGet();
 
         List<ResolvedEvent> events2 = Flowable.fromPublisher(client.readStreamReactive("dataset20M-1800", options))
+                .filter(ReadMessage::hasEvent)
+                .map(ReadMessage::getEvent)
                 .collect(toList())
                 .blockingGet();
 

--- a/db-client-java/src/test/java/com/eventstore/dbclient/SubscribePersistentSubscriptionToStreamTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/SubscribePersistentSubscriptionToStreamTests.java
@@ -66,7 +66,7 @@ public class SubscribePersistentSubscriptionToStreamTests extends ESDBTests {
             private int count = 0;
 
             @Override
-            public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+            public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent event) {
                 ++this.count;
 
                 subscription.ack(event);
@@ -123,7 +123,7 @@ public class SubscribePersistentSubscriptionToStreamTests extends ESDBTests {
             private int count = 0;
 
             @Override
-            public void onEvent(PersistentSubscription subscription, ResolvedEvent resolvedEvent) {
+            public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent resolvedEvent) {
                 RecordedEvent event = resolvedEvent.getEvent();
 
                 subscription.ack(resolvedEvent);

--- a/db-client-java/src/test/java/com/eventstore/dbclient/samples/persistent_subscriptions/PersistentSubscriptions.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/samples/persistent_subscriptions/PersistentSubscriptions.java
@@ -24,7 +24,7 @@ public class PersistentSubscriptions {
             "subscription-group",
             new PersistentSubscriptionListener() {
                 @Override
-                public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+                public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent event) {
                     System.out.println("Received event"
                         + event.getOriginalEvent().getStreamRevision()
                         + "@" + event.getOriginalEvent().getStreamId());
@@ -52,7 +52,7 @@ public class PersistentSubscriptions {
                 "subscription-group",
                 new PersistentSubscriptionListener() {
                     @Override
-                    public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+                    public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent event) {
                         try {
                             System.out.println("Received event"
                                     + event.getOriginalEvent().getStreamRevision()
@@ -82,7 +82,7 @@ public class PersistentSubscriptions {
             "subscription-group",
             new PersistentSubscriptionListener() {
                 @Override
-                public void onEvent(PersistentSubscription subscription, ResolvedEvent event) {
+                public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent event) {
                     try {
                         System.out.println("Received event"
                             + event.getOriginalEvent().getStreamRevision()

--- a/db-client-java/src/test/java/testcontainers/module/EventStoreDB.java
+++ b/db-client-java/src/test/java/testcontainers/module/EventStoreDB.java
@@ -36,6 +36,10 @@ public class EventStoreDB extends GenericContainer<EventStoreDB> {
         return Optional.ofNullable(System.getenv("EVENTSTORE_DOCKER_TAG_ENV")).orElse(IMAGE_TAG).startsWith("20");
     }
 
+    public static boolean isTestedAgains20_10() {
+        return Optional.ofNullable(System.getenv("EVENTSTORE_DOCKER_TAG_ENV")).orElse(IMAGE_TAG).startsWith("20.10");
+    }
+
     private final EventStoreDBClientSettings settings;
     private final EventStoreDBClient client;
     private final EventStoreDBPersistentSubscriptionsClient persistentSubscriptionsClient;


### PR DESCRIPTION
This PR exposes:
* the first and last event number of a stream when reading (regular read and subscriptions)
* retry count when consuming a persistent subscription.