### PR TITLE
Add getServerVersion() api method and update dataset log positions / tests

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ServerFeatures.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ServerFeatures.java
@@ -44,7 +44,7 @@ class ServerFeatures {
         stub.getSupportedMethods(Shared.Empty.getDefaultInstance(), convertSingleResponse(result, resp -> {
             int major = 0, minor = 0, patch = 0;
 
-            String[] splits = resp.getEventStoreServerVersion().split(".");
+            String[] splits = resp.getEventStoreServerVersion().split("\\.");
             for (int idx = 0; idx < splits.length; idx++) {
                 if (idx > 2) {
                     break;

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ServerInfo.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ServerInfo.java
@@ -12,4 +12,5 @@ class ServerInfo {
     public boolean supportFeature(int feature) {
         return (features & feature) != 0;
     }
+    public ServerVersion getServerVersion() { return version; }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ServerVersion.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ServerVersion.java
@@ -21,4 +21,29 @@ class ServerVersion {
     public int getPatch() {
         return patch;
     }
+
+    public boolean isGreaterThan(int major, int minor, int patch) {
+        return !isLessThan(major, minor, patch) &&
+                !equals(major, minor, patch);
+    }
+
+    public boolean equals(int major, int minor, int patch) {
+        return this.major == major
+                && this.minor == minor
+                && this.patch == patch;
+    }
+
+    public boolean isLessThan(int major, int minor, int patch) {
+        int cmp;
+        if ((cmp = Integer.compare(this.major, major)) != 0)
+            return cmp < 0;
+
+        if ((cmp = Integer.compare(this.minor, minor)) != 0)
+            return cmp < 0;
+
+        if ((cmp = Integer.compare(this.patch, patch)) != 0)
+            return cmp < 0;
+
+        return false;
+    }
 }

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ServerVersionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ServerVersionTests.java
@@ -1,0 +1,51 @@
+package com.eventstore.dbclient;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ServerVersionTests {
+    @Test
+    public void testEquals() {
+        ServerVersion v = new ServerVersion(22, 6, 123);
+
+        Assertions.assertTrue(v.equals(22, 6, 123));
+
+        Assertions.assertFalse(v.equals(21, 6, 123));
+        Assertions.assertFalse(v.equals(22, 5, 123));
+        Assertions.assertFalse(v.equals(22, 6, 124));
+    }
+
+    @Test
+    public void testIsLessThan() {
+        ServerVersion v = new ServerVersion(22, 6, 123);
+
+        Assertions.assertFalse(v.isLessThan(22, 6, 123));
+
+        Assertions.assertTrue(v.isLessThan(23, 6, 123));
+        Assertions.assertTrue(v.isLessThan(22, 7, 123));
+        Assertions.assertTrue(v.isLessThan(22, 6, 124));
+
+        Assertions.assertFalse(v.isLessThan(21, 6, 123));
+        Assertions.assertFalse(v.isLessThan(22, 5, 123));
+        Assertions.assertFalse(v.isLessThan(22, 6, 122));
+
+        Assertions.assertTrue(v.isLessThan(23, 5, 123));
+    }
+
+    @Test
+    public void testIsGreaterThan() {
+        ServerVersion v = new ServerVersion(22, 6, 123);
+
+        Assertions.assertFalse(v.isGreaterThan(22, 6, 123));
+
+        Assertions.assertTrue(v.isGreaterThan(21, 6, 123));
+        Assertions.assertTrue(v.isGreaterThan(22, 5, 123));
+        Assertions.assertTrue(v.isGreaterThan(22, 6, 122));
+
+        Assertions.assertFalse(v.isGreaterThan(23, 6, 123));
+        Assertions.assertFalse(v.isGreaterThan(22, 7, 123));
+        Assertions.assertFalse(v.isGreaterThan(22, 6, 124));
+
+        Assertions.assertTrue(v.isGreaterThan(21, 7, 123));
+    }
+}

--- a/db-client-java/src/test/resources/dataset20M-1800-e0-e10.json
+++ b/db-client-java/src/test/resources/dataset20M-1800-e0-e10.json
@@ -54,8 +54,8 @@
         "nanos": 245917000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11607400,
+        "commit": 11607400
       },
       "contentType": "application/json"
     }
@@ -115,8 +115,8 @@
         "nanos": 245936000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11607557,
+        "commit": 11607557
       },
       "contentType": "application/json"
     }
@@ -176,8 +176,8 @@
         "nanos": 245940000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11607714,
+        "commit": 11607714
       },
       "contentType": "application/json"
     }
@@ -237,8 +237,8 @@
         "nanos": 245943000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11607871,
+        "commit": 11607871
       },
       "contentType": "application/json"
     }
@@ -298,8 +298,8 @@
         "nanos": 245955000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11608028,
+        "commit": 11608028
       },
       "contentType": "application/json"
     }
@@ -359,8 +359,8 @@
         "nanos": 245958000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11608185,
+        "commit": 11608185
       },
       "contentType": "application/json"
     }
@@ -420,8 +420,8 @@
         "nanos": 245962000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11608342,
+        "commit": 11608342
       },
       "contentType": "application/json"
     }
@@ -481,8 +481,8 @@
         "nanos": 245964000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11608499,
+        "commit": 11608499
       },
       "contentType": "application/json"
     }
@@ -542,8 +542,8 @@
         "nanos": 245968000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11608656,
+        "commit": 11608656
       },
       "contentType": "application/json"
     }
@@ -603,8 +603,8 @@
         "nanos": 245970000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 11608813,
+        "commit": 11608813
       },
       "contentType": "application/json"
     }

--- a/db-client-java/src/test/resources/dataset20M-1800-e1999-e1990.json
+++ b/db-client-java/src/test/resources/dataset20M-1800-e1999-e1990.json
@@ -54,8 +54,8 @@
         "nanos": 521770000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12237319,
+        "commit": 12237319
       },
       "contentType": "application/json"
     }
@@ -115,8 +115,8 @@
         "nanos": 521767000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12237162,
+        "commit": 12237162
       },
       "contentType": "application/json"
     }
@@ -176,8 +176,8 @@
         "nanos": 521765000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12237005,
+        "commit": 12237005
       },
       "contentType": "application/json"
     }
@@ -237,8 +237,8 @@
         "nanos": 521762000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12236848,
+        "commit": 12236848
       },
       "contentType": "application/json"
     }
@@ -298,8 +298,8 @@
         "nanos": 521759000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12236691,
+        "commit": 12236691
       },
       "contentType": "application/json"
     }
@@ -359,8 +359,8 @@
         "nanos": 521756000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12236534,
+        "commit": 12236534
       },
       "contentType": "application/json"
     }
@@ -420,8 +420,8 @@
         "nanos": 521753000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12236377,
+        "commit": 12236377
       },
       "contentType": "application/json"
     }
@@ -481,8 +481,8 @@
         "nanos": 521750000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12236220,
+        "commit": 12236220
       },
       "contentType": "application/json"
     }
@@ -542,8 +542,8 @@
         "nanos": 521748000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12236063,
+        "commit": 12236063
       },
       "contentType": "application/json"
     }
@@ -603,8 +603,8 @@
         "nanos": 521745000
       },
       "position": {
-        "prepare": -1,
-        "commit": -1
+        "prepare": 12235906,
+        "commit": 12235906
       },
       "contentType": "application/json"
     }


### PR DESCRIPTION
Added: getServerVersion() api method
Updated: datasets with real prepare/commit log positions
Updated: read stream tests to cater for log position changes on the server
Fixed: bug in version parsing