### PR TITLE
Issue-171: Fix error signals to the GrpcClient based on a Completable…

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadSubscription.java
@@ -28,10 +28,6 @@ class ReadSubscription implements Subscription {
         this.streamObserver = streamObserver;
     }
 
-    public void onStreamNotFound() {
-        subscriber.onError(new StreamNotFoundException());
-    }
-
     public void onError(Throwable error) {
         if (error instanceof StatusRuntimeException) {
             StatusRuntimeException statusRuntimeException = (StatusRuntimeException) error;


### PR DESCRIPTION
Bugfix for https://github.com/EventStore/EventStoreDB-Client-Java/issues/171

Properly signal errors to the `GrpcClient` to support connection failover on read stream operations in a clustered environment.