### PR TITLE
Fix typo in method name.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClient.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClient.java
@@ -352,7 +352,7 @@ public class EventStoreDBClient extends EventStoreDBClientBase {
      * @see DeleteResult
      * @return if successful, delete result.
      */
-    public CompletableFuture<DeleteResult> tombstoneStrSeam(String streamName, DeleteStreamOptions options) {
+    public CompletableFuture<DeleteResult> tombstoneStream(String streamName, DeleteStreamOptions options) {
         if (options == null)
             options = DeleteStreamOptions.get();
 


### PR DESCRIPTION
Found a simple typo in a method while preparing to adapt to new API.