### PR TITLE
Issue 161 Force shutdown after grace period

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/GrpcClient.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/GrpcClient.java
@@ -304,7 +304,10 @@ abstract class GrpcClient {
     private void closeConnection() {
         if (this.channel != null) {
             try {
-                this.channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+                boolean terminated = this.channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+                if (!terminated) {
+                    this.channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+                }
             } catch (InterruptedException e) {
                 logger.error("Error when closing gRPC channel", e);
             } finally {


### PR DESCRIPTION
This is another backport to the 3.0.0 release branch for issues fixed on trunk/4.x release:
https://github.com/EventStore/EventStoreDB-Client-Java/issues/161

Performs a forced shutdown of gRPC ManagedChannel if normal shutdown does not terminate the `ManagedChannel`.