### PR TITLE
Implement human-representation for ExpectedVersion types.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ExpectedRevision.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ExpectedRevision.java
@@ -16,7 +16,7 @@ import java.util.Objects;
  */
 public abstract class ExpectedRevision {
     /**
-     * This write should not conflict with anything and should always succeed.
+     * This writes should not conflict with anything and should always succeed.
      */
     public static ExpectedRevision any() {
         return new AnyExpectedRevision();
@@ -75,6 +75,11 @@ public abstract class ExpectedRevision {
         public StreamsOuterClass.TombstoneReq.Options.Builder applyOnWire(StreamsOuterClass.TombstoneReq.Options.Builder options) {
             return options.setNoStream(Shared.Empty.getDefaultInstance());
         }
+
+        @Override
+        public String toString() {
+            return "ExpectedNoStream";
+        }
     }
 
     static class AnyExpectedRevision extends ExpectedRevision {
@@ -92,6 +97,11 @@ public abstract class ExpectedRevision {
         public StreamsOuterClass.TombstoneReq.Options.Builder applyOnWire(StreamsOuterClass.TombstoneReq.Options.Builder options) {
             return options.setAny(Shared.Empty.getDefaultInstance());
         }
+
+        @Override
+        public String toString() {
+            return "ExpectedAny";
+        }
     }
 
     static class StreamExistsExpectedRevision extends ExpectedRevision {
@@ -108,6 +118,11 @@ public abstract class ExpectedRevision {
         @Override
         public StreamsOuterClass.TombstoneReq.Options.Builder applyOnWire(StreamsOuterClass.TombstoneReq.Options.Builder options) {
             return options.setStreamExists(Shared.Empty.getDefaultInstance());
+        }
+
+        @Override
+        public String toString() {
+            return "ExpectedStreamExists";
         }
     }
 
@@ -144,6 +159,11 @@ public abstract class ExpectedRevision {
         @Override
         public StreamsOuterClass.TombstoneReq.Options.Builder applyOnWire(StreamsOuterClass.TombstoneReq.Options.Builder options) {
             return options.setRevision(version);
+        }
+
+        @Override
+        public String toString() {
+            return Long.toString(this.version);
         }
     }
 }

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ExpectedRevisionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ExpectedRevisionTests.java
@@ -32,4 +32,11 @@ public class ExpectedRevisionTests {
         Assertions.assertEquals(ExpectedRevision.expectedRevision(1L).hashCode(), ExpectedRevision.expectedRevision(1L).hashCode());
     }
 
+    @Test
+    public void testHumanRepresentation() {
+        Assertions.assertEquals("ExpectedAny", ExpectedRevision.any().toString());
+        Assertions.assertEquals("ExpectedStreamExists", ExpectedRevision.streamExists().toString());
+        Assertions.assertEquals("ExpectedNoStream", ExpectedRevision.noStream().toString());
+        Assertions.assertEquals("42", ExpectedRevision.expectedRevision(42).toString());
+    }
 }


### PR DESCRIPTION
Fixes #203 

Each `ExpectedVersion` subclass overrides `toString`.

```
ExpectedVersion.NoStreamExpectedRevision -> "ExpectedNoStream"
ExpectedVersion.AnyExpectedRevision -> "ExpectedAny"
ExpectedVersion.StreamExistsExpectedRevision -> "ExpectedStreamExists"
ExpectedVersion.SpecificExpectedRevision(42) -> "42"
```