### PR TITLE
fix(EventDataBuilder): divided JSON and binary EventDataBinary

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventData.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventData.java
@@ -84,7 +84,7 @@ public final class EventData {
      * @param eventData event's payload.
      * @return an event data builder.
      */
-    public static EventDataBuilder builderAsBinary(String eventType, byte[] eventData) {
+    public static EventDataBinaryBuilder builderAsBinary(String eventType, byte[] eventData) {
         return builderAsBinary(null, eventType, eventData);
     }
 
@@ -95,8 +95,7 @@ public final class EventData {
      * @param eventData event's payload.
      * @return an event data builder.
      */
-    public static EventDataBuilder builderAsBinary(UUID eventId, String eventType, byte[] eventData) {
-        return EventDataBuilder.binary(eventId, eventType, eventData);
+    public static EventDataBinaryBuilder builderAsBinary(UUID eventId, String eventType, byte[] eventData) {
+        return EventDataBinaryBuilder.binary(eventId, eventType, eventData);
     }
 }
-

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBinaryBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBinaryBuilder.java
@@ -1,0 +1,70 @@
+package com.eventstore.dbclient;
+
+import java.util.UUID;
+
+/**
+ * Utility class to help building an <i>EventData</i>.
+ */
+public class EventDataBinaryBuilder {
+    private byte[] eventData;
+    private byte[] metadata;
+    private String eventType;
+    private boolean isJson;
+    private UUID id;
+
+    EventDataBinaryBuilder(){}
+
+    /**
+     * Configures an event data builder to host a binary payload.
+     * @param eventType event's type.
+     * @param eventData event's payload.
+     * @return an event data builder.
+     */
+    public static EventDataBinaryBuilder binary(String eventType, byte[] eventData) {
+        return binary(null, eventType, eventData);
+    }
+
+    /**
+     * Configures an event data builder to host a binary payload.
+     * @param id event's id.
+     * @param eventType event's type.
+     * @param eventData event's payload.
+     * @return an event data builder.
+     */
+    public static EventDataBinaryBuilder binary(UUID id, String eventType, byte[] eventData) {
+        EventDataBinaryBuilder self = new EventDataBinaryBuilder();
+
+        self.eventData = eventData;
+        self.eventType = eventType;
+        self.isJson = false;
+        self.id = id;
+
+        return self;
+    }
+
+    /**
+     * Sets event's unique identifier.
+     */
+    public EventDataBinaryBuilder eventId(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Sets event's custom user metadata.
+     */
+    public EventDataBinaryBuilder metadataAsBytes(byte[] value) {
+        this.metadata = value;
+        return this;
+    }
+
+    /**
+     * Builds an event ready to be sent to EventStoreDB.
+     * @see EventData
+     */
+    public EventData build() {
+        UUID eventId = this.id == null ? UUID.randomUUID() : this.id;
+        String contentType = this.isJson ? "application/json" : "application/octet-stream";
+        return new EventData(eventId, this.eventType, contentType, this.eventData, this.metadata);
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 /**
  * Utility class to help building an <i>EventData</i>.
  */
-public class EventDataBuilder {
+public class EventDataBuilder extends EventDataBinaryBuilder {
     private static final JsonMapper mapper = new JsonMapper();
     private byte[] eventData;
     private byte[] metadata;
@@ -72,34 +72,6 @@ public class EventDataBuilder {
     }
 
     /**
-     * Configures an event data builder to host a binary payload.
-     * @param eventType event's type.
-     * @param eventData event's payload.
-     * @return an event data builder.
-     */
-    public static EventDataBuilder binary(String eventType, byte[] eventData) {
-        return binary(null, eventType, eventData);
-    }
-
-    /**
-     * Configures an event data builder to host a binary payload.
-     * @param id event's id.
-     * @param eventType event's type.
-     * @param eventData event's payload.
-     * @return an event data builder.
-     */
-    public static EventDataBuilder binary(UUID id, String eventType, byte[] eventData) {
-        EventDataBuilder self = new EventDataBuilder();
-
-        self.eventData = eventData;
-        self.eventType = eventType;
-        self.isJson = false;
-        self.id = id;
-
-        return self;
-    }
-
-    /**
      * Sets event's unique identifier.
      */
     public EventDataBuilder eventId(UUID id) {
@@ -118,14 +90,6 @@ public class EventDataBuilder {
             throw new RuntimeException(e);
         }
 
-        return this;
-    }
-
-    /**
-     * Sets event's custom user metadata.
-     */
-    public EventDataBuilder metadataAsBytes(byte[] value) {
-        this.metadata = value;
         return this;
     }
 


### PR DESCRIPTION
https://github.com/EventStore/EventStoreDB-Client-Java/issues/216

When we trying to create a new 'EventDate' using 'EventDataBuilder' we have new exception, because in this builder hardcoded 'JsonMapper'.