### PR TITLE
Stop using Jackson JsonMapper static instances.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
@@ -9,7 +9,6 @@ import java.util.UUID;
  * Utility class to help building an <i>EventData</i>.
  */
 public class EventDataBuilder {
-    private static final JsonMapper mapper = new JsonMapper();
     private byte[] eventData;
     private byte[] metadata;
     private String eventType;
@@ -37,8 +36,10 @@ public class EventDataBuilder {
      * @return an event data builder.
      * @param <A> a type that can be serialized in JSON.
      */
+    @Deprecated
     public static <A> EventDataBuilder json(UUID id, String eventType, A eventData) {
         try {
+            JsonMapper mapper = new JsonMapper();
             return json(id, eventType, mapper.writeValueAsBytes(eventData));
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
@@ -111,8 +112,10 @@ public class EventDataBuilder {
      * Sets event's custom user metadata.
      * @param <A> an object that can be serialized in JSON.
      */
+    @Deprecated
     public <A> EventDataBuilder metadataAsJson(A value) {
         try {
+            JsonMapper mapper = new JsonMapper();
             this.metadata = mapper.writeValueAsBytes(value);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClient.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClient.java
@@ -1,5 +1,6 @@
 package com.eventstore.dbclient;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
@@ -179,8 +180,9 @@ public class EventStoreDBClient extends EventStoreDBClientBase {
             CompletableFuture<StreamMetadata> out = new CompletableFuture<>();
 
             try {
+                JsonMapper mapper = new JsonMapper();
                 @SuppressWarnings("unchecked")
-                HashMap<String, Object> source = event.getEventDataAs(HashMap.class);
+                HashMap<String, Object> source = mapper.readValue(event.getEventData(), HashMap.class);
 
                 out.complete(StreamMetadata.deserialize(source));
             } catch (Throwable e) {

--- a/db-client-java/src/main/java/com/eventstore/dbclient/RecordedEvent.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/RecordedEvent.java
@@ -35,8 +35,6 @@ public class RecordedEvent {
     @NotNull
     private final String contentType;
 
-    private static final JsonMapper mapper = new JsonMapper();
-
     RecordedEvent(
             @NotNull String eventStreamId,
             @NotNull long streamRevision,
@@ -111,7 +109,9 @@ public class RecordedEvent {
     /**
      * Deserialized representation of the event's payload. In this case, the payload is supposed to be JSON.
      */
+    @Deprecated
     public <A> A getEventDataAs(Class<A> clazz) throws IOException {
+        JsonMapper mapper = new JsonMapper();
         return mapper.readValue(this.getEventData(), clazz);
     }
 

--- a/db-client-java/src/test/java/com/eventstore/dbclient/AppendTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/AppendTests.java
@@ -1,5 +1,6 @@
 package com.eventstore.dbclient;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import testcontainers.module.ESDBTests;
@@ -67,11 +68,12 @@ public class AppendTests extends ESDBTests {
 
         Assertions.assertEquals(1, result.getEvents().size());
         RecordedEvent first = result.getEvents().get(0).getEvent();
+        JsonMapper mapper = new JsonMapper();
 
         Assertions.assertEquals(streamName, first.getStreamId());
         Assertions.assertEquals(eventType, first.getEventType());
         Assertions.assertEquals(eventId, first.getEventId().toString());
         Assertions.assertArrayEquals(eventMetaData, first.getUserMetadata());
-        Assertions.assertEquals(new Foo(), first.getEventDataAs(Foo.class));
+        Assertions.assertEquals(new Foo(), mapper.readValue(first.getEventData(), Foo.class));
     }
 }


### PR DESCRIPTION
Changed: Stop using Jackson JsonMapper static instances.

Fixes #216 