### PR TITLE
Implement `ExpectedRevision` raw long representation.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ExpectedRevision.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ExpectedRevision.java
@@ -43,13 +43,16 @@ public abstract class ExpectedRevision {
         return new SpecificExpectedRevision(revision);
     }
 
-    static ExpectedRevision fromRaw(long revision) {
+    public static ExpectedRevision fromRawLong(long revision) {
         if (revision == -1)
             return ExpectedRevision.noStream();
         if (revision == -2)
             return ExpectedRevision.any();
         if (revision == -4)
             return ExpectedRevision.streamExists();
+
+        if (revision < 0)
+            throw new RuntimeException(String.format("Invalid expected revision long representation '%s'", revision));
 
         return ExpectedRevision.expectedRevision(revision);
     }
@@ -59,6 +62,21 @@ public abstract class ExpectedRevision {
     abstract StreamsOuterClass.AppendReq.Options.Builder applyOnWire(StreamsOuterClass.AppendReq.Options.Builder options);
     abstract StreamsOuterClass.DeleteReq.Options.Builder applyOnWire(StreamsOuterClass.DeleteReq.Options.Builder options);
     abstract StreamsOuterClass.TombstoneReq.Options.Builder applyOnWire(StreamsOuterClass.TombstoneReq.Options.Builder options);
+
+    public long toRawLong() {
+        if (this instanceof  NoStreamExpectedRevision)
+            return -1;
+
+        if (this instanceof AnyExpectedRevision)
+            return -2;
+
+        if (this instanceof StreamExistsExpectedRevision)
+            return -4;
+
+        SpecificExpectedRevision revision = (SpecificExpectedRevision) this;
+
+        return revision.version;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/db-client-java/src/main/java/com/eventstore/dbclient/GrpcUtils.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/GrpcUtils.java
@@ -10,7 +10,6 @@ import io.grpc.stub.*;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 final class GrpcUtils {
     static public <ReqT, RespT> ClientResponseObserver<ReqT, RespT> convertSingleResponse(
@@ -62,8 +61,8 @@ final class GrpcUtils {
                             }
 
                             try {
-                                ExpectedRevision expected = ExpectedRevision.fromRaw(Long.parseLong(expectedStr));
-                                ExpectedRevision actual = ExpectedRevision.fromRaw(Long.parseLong(actualStr));
+                                ExpectedRevision expected = ExpectedRevision.fromRawLong(Long.parseLong(expectedStr));
+                                ExpectedRevision actual = ExpectedRevision.fromRawLong(Long.parseLong(actualStr));
 
                                 dest.completeExceptionally(new WrongExpectedVersionException(streamName, expected, actual));
                                 return;

--- a/db-client-java/src/test/java/com/eventstore/dbclient/ExpectedRevisionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/ExpectedRevisionTests.java
@@ -39,4 +39,21 @@ public class ExpectedRevisionTests {
         Assertions.assertEquals("ExpectedNoStream", ExpectedRevision.noStream().toString());
         Assertions.assertEquals("42", ExpectedRevision.expectedRevision(42).toString());
     }
+
+    @Test
+    public void testRawLong() {
+        Assertions.assertEquals(-2, ExpectedRevision.any().toRawLong());
+        Assertions.assertEquals(-1, ExpectedRevision.noStream().toRawLong());
+        Assertions.assertEquals(-4, ExpectedRevision.streamExists().toRawLong());
+        Assertions.assertEquals(42, ExpectedRevision.expectedRevision(42).toRawLong());
+    }
+
+    @Test
+    public void testRawLongConversion() {
+        Assertions.assertEquals(ExpectedRevision.fromRawLong(-2), ExpectedRevision.any());
+        Assertions.assertEquals(ExpectedRevision.fromRawLong(-1), ExpectedRevision.noStream());
+        Assertions.assertEquals(ExpectedRevision.fromRawLong(-4), ExpectedRevision.streamExists());
+        Assertions.assertEquals(ExpectedRevision.fromRawLong(42), ExpectedRevision.expectedRevision(42));
+        Assertions.assertThrowsExactly(RuntimeException.class, () -> ExpectedRevision.fromRawLong(-5));
+    }
 }


### PR DESCRIPTION
Added: Implement `ExpectedRevision` raw long representation.

Fixes #228 