### PR TITLE
Support user-provided gRPC client interceptors.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ConnectionSettingsBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ConnectionSettingsBuilder.java
@@ -1,11 +1,14 @@
 package com.eventstore.dbclient;
 
 
+import io.grpc.ClientInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Utility to create client settings programmatically.
@@ -25,6 +28,7 @@ public class ConnectionSettingsBuilder {
     private long _keepAliveTimeout = Consts.DEFAULT_KEEP_ALIVE_TIMEOUT_IN_MS;
     private long _keepAliveInterval = Consts.DEFAULT_KEEP_ALIVE_INTERVAL_IN_MS;
     private Long _defaultDeadline = null;
+    private List<ClientInterceptor> _interceptors = new ArrayList<>();
 
     ConnectionSettingsBuilder() {}
 
@@ -46,7 +50,8 @@ public class ConnectionSettingsBuilder {
                 _hosts.toArray(new InetSocketAddress[0]),
                 _keepAliveTimeout,
                 _keepAliveInterval,
-                _defaultDeadline);
+                _defaultDeadline,
+                _interceptors);
     }
 
     /**
@@ -173,6 +178,15 @@ public class ConnectionSettingsBuilder {
      */
     public ConnectionSettingsBuilder defaultDeadline(long value) {
         this._defaultDeadline = value;
+        return this;
+    }
+
+    /**
+     * Register a gRPC interceptor every time a new gRPC channel is created.
+     * @param interceptor
+     */
+    public ConnectionSettingsBuilder addInterceptor(ClientInterceptor interceptor) {
+        this._interceptors.add(interceptor);
         return this;
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ConnectionState.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ConnectionState.java
@@ -59,7 +59,8 @@ class ConnectionState {
 
         NettyChannelBuilder builder = NettyChannelBuilder
                 .forAddress(addr)
-                .maxInboundMessageSize(MAX_INBOUND_MESSAGE_LENGTH);
+                .maxInboundMessageSize(MAX_INBOUND_MESSAGE_LENGTH)
+                .intercept(settings.getInterceptors());
 
         if (this.sslContext == null) {
             builder.usePlaintext();

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClientSettings.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClientSettings.java
@@ -1,6 +1,9 @@
 package com.eventstore.dbclient;
 
+import io.grpc.ClientInterceptor;
+
 import java.net.InetSocketAddress;
+import java.util.List;
 
 /**
  * Gathers all the settings related to a gRPC client with an EventStoreDB database.
@@ -35,6 +38,7 @@ public class EventStoreDBClientSettings {
     private final long keepAliveTimeout;
     private final long keepAliveInterval;
     private final Long defaultDeadline;
+    private final List<ClientInterceptor> interceptors;
 
     /**
      * If the dns discovery is enabled.
@@ -136,6 +140,14 @@ public class EventStoreDBClientSettings {
         return defaultDeadline;
     }
 
+    /**
+     * Registered gRPC interceptors.
+     * @return list of registered gRPC client.
+     */
+    public List<ClientInterceptor> getInterceptors() {
+        return interceptors;
+    }
+
     EventStoreDBClientSettings(
             boolean dnsDiscover,
             int maxDiscoverAttempts,
@@ -149,7 +161,8 @@ public class EventStoreDBClientSettings {
             InetSocketAddress[] hosts,
             long keepAliveTimeout,
             long keepAliveInterval,
-            Long defaultDeadline
+            Long defaultDeadline,
+            List<ClientInterceptor> interceptors
     ) {
         this.dnsDiscover = dnsDiscover;
         this.maxDiscoverAttempts = maxDiscoverAttempts;
@@ -164,6 +177,7 @@ public class EventStoreDBClientSettings {
         this.keepAliveTimeout = keepAliveTimeout;
         this.keepAliveInterval = keepAliveInterval;
         this.defaultDeadline = defaultDeadline;
+        this.interceptors = interceptors;
     }
 
     /**

--- a/db-client-java/src/test/java/com/eventstore/dbclient/InterceptorTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/InterceptorTests.java
@@ -1,0 +1,41 @@
+package com.eventstore.dbclient;
+
+import io.grpc.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import testcontainers.module.ESDBTests;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InterceptorTests extends ESDBTests {
+    @Test
+    public void testInterceptorIsCalled() {
+        EventStoreDBClientSettings settings = getEmptyServer().getSettings();
+
+        AtomicInteger atom = new AtomicInteger(0);
+
+        settings.getInterceptors().add(new MyInterceptor(atom));
+
+        EventStoreDBClient client = EventStoreDBClient.create(settings);
+        try {
+            client.readStream("foobar", ReadStreamOptions.get()).get();
+        } catch (Exception e) {
+            // We don't care.
+        }
+
+        Assertions.assertEquals(42, atom.get());
+    }
+
+    class MyInterceptor implements ClientInterceptor {
+        final AtomicInteger atom;
+
+        MyInterceptor(AtomicInteger atom) {
+            this.atom = atom;
+        }
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+            atom.set(42);
+            return next.newCall(method, callOptions);
+        }
+    }
+}


### PR DESCRIPTION
Added: Support user-provided gRPC client interceptors.

You can know pass your gRPC interceptor(s) in 2 different ways, depending on how you create your connection settings instance.

### connection string

```java
    EventStoreDBClientSettings settings = EventStoreDBClientSettings.parseOrThrow("{connection string}")

    settings.getInterceptors().add(myGrpcClientInterceptor);
   
    EventStoreDBClient client = EventStoreDBClient.create(settings);
    
   // rest of your application
```

### connection builder

```java
   EventStoreDBClientSettings settings = EventStoreDBClientSettings.newBuilder()
       .addInterceptor(myGrpcClientInterceptor)
       .buildConnectionSettings();

   EventStoreDBClient client = EventStoreDBClient.create(settings);
    
   // rest of your application
```