### PR TITLE
Fix IllegalStateException when stopping a subscription.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRegularSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRegularSubscription.java
@@ -111,9 +111,9 @@ abstract class AbstractRegularSubscription {
                     Throwable error = throwable;
                     if (error instanceof StatusRuntimeException) {
                         StatusRuntimeException sre = (StatusRuntimeException) error;
-                        if (sre.getStatus().getCode() == Status.Code.CANCELLED) {
+                        String desc = sre.getStatus().getDescription();
+                        if (sre.getStatus().getCode() == Status.Code.CANCELLED && desc != null && desc.equals("user-initiated")) {
                             listener.onCancelled(this._subscription, null);
-                            _requestStream.onCompleted();
                             return;
                         }
 
@@ -126,7 +126,6 @@ abstract class AbstractRegularSubscription {
                     }
 
                     listener.onCancelled(this._subscription, error);
-                    _requestStream.onError(Status.fromThrowable(error).asRuntimeException());
                 }
 
                 @Override

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
@@ -106,9 +106,9 @@ abstract class AbstractSubscribePersistentSubscription {
                         Throwable error = throwable;
                         if (error instanceof StatusRuntimeException) {
                             StatusRuntimeException sre = (StatusRuntimeException) error;
-                            if (sre.getStatus().getCode() == Status.Code.CANCELLED) {
+                            String desc = sre.getStatus().getDescription();
+                            if (sre.getStatus().getCode() == Status.Code.CANCELLED && desc != null && desc.equals("user-initiated")) {
                                 listener.onCancelled(this._subscription, null);
-                                _requestStream.onCompleted();
                                 return;
                             }
 
@@ -121,7 +121,6 @@ abstract class AbstractSubscribePersistentSubscription {
                         }
 
                         listener.onCancelled(this._subscription, error);
-                        _requestStream.onError(Status.fromThrowable(error).asRuntimeException());
                     }
 
                     @Override

--- a/db-client-java/src/test/java/com/eventstore/dbclient/streams/SubscriptionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/streams/SubscriptionTests.java
@@ -133,4 +133,23 @@ public interface SubscriptionTests extends ConnectionAware {
         Assertions.assertEquals(expected.size(), count.get());
         subscription.stop();
     }
+
+    @Test
+    default void testCancellingSubscriptionShouldNotRaiseAnException() throws Throwable {
+        EventStoreDBClient client = getDefaultClient();
+        String streamName = generateName();
+        String eventType = generateName();
+
+        client.appendToStream(streamName, EventData.builderAsJson(eventType, "Hello World").build()).get(60, TimeUnit.SECONDS);
+
+        Subscription sub = client.subscribeToAll(new SubscriptionListener() {
+            @Override
+            public void onCancelled(Subscription subscription, Throwable exception) {
+                if (exception != null)
+                    Assertions.fail(exception);
+            }
+        }).get(60, TimeUnit.SECONDS);
+
+        sub.stop();
+    }
 }


### PR DESCRIPTION
Fixed: Fix IllegalStateException when stopping a subscription.

Fixes #248 

While I added a test, the exception is not thrown to the user thread so can't be captured. Prior the patch we could see this stackstrace in the log:

```
SEVERE: Exception while executing runnable io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed@707b11e9
java.lang.IllegalStateException: call was cancelled
	at com.google.common.base.Preconditions.checkState(Preconditions.java:512)
	at io.grpc.internal.ClientCallImpl.halfCloseInternal(ClientCallImpl.java:510)
	at io.grpc.internal.ClientCallImpl.halfClose(ClientCallImpl.java:504)
	at io.grpc.PartialForwardingClientCall.halfClose(PartialForwardingClientCall.java:44)
	at io.grpc.ForwardingClientCall.halfClose(ForwardingClientCall.java:22)
	at io.grpc.ForwardingClientCall$SimpleForwardingClientCall.halfClose(ForwardingClientCall.java:44)
	at io.grpc.stub.ClientCalls$CallToStreamObserverAdapter.onCompleted(ClientCalls.java:379)
	at com.eventstore.dbclient.AbstractRegularSubscription$1.onError(AbstractRegularSubscription.java:116)
	at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:481)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:574)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:72)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:742)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:723)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

The exception is no longer raised. The culprit was when calling `stop` on the subscription, we already close the internal gRPC stream. By calling `onCompleted` on the observer, we broke the gRPC library expectation to close or cancel a gRPC stream only once.

The patch also fix persistent subscriptions too.