### PR TITLE
DEV-282 - Upgrade grpc client and protoc to access arm64 artifact binaries

### DIFF
--- a/db-client-java/build.gradle
+++ b/db-client-java/build.gradle
@@ -136,7 +136,7 @@ test {
 protobuf {
     protoc {
         // The artifact spec for the Protobuf Compiler
-        artifact = 'com.google.protobuf:protoc:3.13.0'
+        artifact = "com.google.protobuf:protoc:${protocVersion}"
     }
     plugins {
         // Optional: an artifact spec for a protoc plugin, with "grpc" as

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,8 @@ group=com.eventstore
 version=1.0-SNAPSHOT
 
 # Dependencies
-grpcVersion=1.59.0
+grpcVersion=1.61.1
+protocVersion=3.25.2
 protobufVersion=3.24.4
 annotationApiVersion=1.3.2
 validationApiVersion=2.0.1.Final


### PR DESCRIPTION
Changed: Updated gRPC client and Protoc to latest, which come with arm64 binaries, enabling compile on arm64