### PR TITLE
DEV-45-3 - Pull es-gencert-cli from Cloudsmith

### DIFF
--- a/configure-tls-for-tests.yml
+++ b/configure-tls-for-tests.yml
@@ -10,7 +10,7 @@ services:
     network_mode: "none"
 
   setup:
-    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     entrypoint: bash
     user: "1000:1000"
     command: >

--- a/configure-tls-for-tests.yml
+++ b/configure-tls-for-tests.yml
@@ -10,7 +10,7 @@ services:
     network_mode: "none"
 
   setup:
-    image: ghcr.io/eventstore/es-gencert-cli:1.3.0
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
     entrypoint: bash
     user: "1000:1000"
     command: >

--- a/configure-user-certs-for-tests.yml
+++ b/configure-user-certs-for-tests.yml
@@ -10,7 +10,7 @@ services:
     network_mode: "none"
 
   setup:
-    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     entrypoint: bash
     user: "1000:1000"
     command: >

--- a/configure-user-certs-for-tests.yml
+++ b/configure-user-certs-for-tests.yml
@@ -10,7 +10,7 @@ services:
     network_mode: "none"
 
   setup:
-    image: ghcr.io/eventstore/es-gencert-cli:1.3.0
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
     entrypoint: bash
     user: "1000:1000"
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     network_mode: none
 
   cert-gen:
-    image: ghcr.io/eventstore/es-gencert-cli:1.3.0
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
     entrypoint: bash
     user: "1000:1000"
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     network_mode: none
 
   cert-gen:
-    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     entrypoint: bash
     user: "1000:1000"
     command: >


### PR DESCRIPTION
Changed: Updated everywhere to pull es-gencert-cli from Cloudsmith