### PR TITLE
[DEV-76] Fix ClientTelemetry injection logic forcing JSON content type

### DIFF
--- a/db-client-java/build.gradle
+++ b/db-client-java/build.gradle
@@ -113,8 +113,8 @@ tasks.register("miscTests", Test) {
 
 tasks.register("singleNodeTests", Test) {
     useJUnitPlatform {
-        include("**/StreamsTests.class")
-        include("**/PersistentSubscriptionsTests.class")
+        //("**/StreamsTests.class")
+        //include("**/PersistentSubscriptionsTests.class")
         include("**/TelemetryTests.class")
     }
 }

--- a/db-client-java/build.gradle
+++ b/db-client-java/build.gradle
@@ -113,8 +113,8 @@ tasks.register("miscTests", Test) {
 
 tasks.register("singleNodeTests", Test) {
     useJUnitPlatform {
-        //("**/StreamsTests.class")
-        //include("**/PersistentSubscriptionsTests.class")
+        include("**/StreamsTests.class")
+        include("**/PersistentSubscriptionsTests.class")
         include("**/TelemetryTests.class")
     }
 }
@@ -179,7 +179,7 @@ protobuf {
             // options.  Note the braces cannot be omitted, otherwise the
             // plugin will not be added. This is because of the implicit way
             // NamedDomainObjectContainer binds the methods.
-            grpc { }
+            grpc {}
         }
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ClientTelemetry.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ClientTelemetry.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.Scope;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
@@ -29,11 +30,14 @@ class ClientTelemetry {
 
     private static List<EventData> tryInjectTracingContext(Span span, List<EventData> events) {
         List<EventData> injectedEvents = new ArrayList<>();
-        for (EventData event : events)
+        for (EventData event : events) {
+            boolean isJsonEvent = Objects.equals(event.getContentType(), ContentType.JSON);
+
             injectedEvents.add(EventDataBuilder
-                    .json(event.getEventId(), event.getEventType(), event.getEventData())
+                    .binary(event.getEventId(), event.getEventType(), event.getEventData(), isJsonEvent)
                     .metadataAsBytes(tryInjectTracingContext(span, event.getUserMetadata()))
                     .build());
+        }
         return injectedEvents;
     }
 

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ContentType.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ContentType.java
@@ -2,5 +2,5 @@ package com.eventstore.dbclient;
 
 class ContentType {
     public static final String JSON = "application/json";
-    public static final String OCTET_STREAM = "application/octet-stream";
+    public static final String BYTES = "application/octet-stream";
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ContentType.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ContentType.java
@@ -1,0 +1,6 @@
+package com.eventstore.dbclient;
+
+class ContentType {
+    public static final String JSON = "application/json";
+    public static final String OCTET_STREAM = "application/octet-stream";
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
@@ -155,7 +155,7 @@ public class EventDataBuilder {
      */
     public EventData build() {
         UUID eventId = this.id == null ? UUID.randomUUID() : this.id;
-        String contentType = this.isJson ? ContentType.JSON : ContentType.OCTET_STREAM;
+        String contentType = this.isJson ? ContentType.JSON : ContentType.BYTES;
         return new EventData(eventId, this.eventType, contentType, this.eventData, this.metadata);
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
@@ -15,14 +15,16 @@ public class EventDataBuilder {
     private boolean isJson;
     private UUID id;
 
-    EventDataBuilder(){}
+    EventDataBuilder() {
+    }
 
     /**
      * Configures builder to serialize event data as JSON.
+     *
      * @param eventType event's type.
      * @param eventData event's payload.
+     * @param <A>       a type that can be serialized in JSON.
      * @return an event data builder.
-     * @param <A> a type that can be serialized in JSON.
      */
     public static <A> EventDataBuilder json(String eventType, A eventData) {
         return json(null, eventType, eventData);
@@ -30,11 +32,12 @@ public class EventDataBuilder {
 
     /**
      * Configures an event data builder to host a JSON payload.
-     * @param id event's id.
+     *
+     * @param id        event's id.
      * @param eventType event's type.
      * @param eventData event's payload.
+     * @param <A>       a type that can be serialized in JSON.
      * @return an event data builder.
-     * @param <A> a type that can be serialized in JSON.
      */
     @Deprecated
     public static <A> EventDataBuilder json(UUID id, String eventType, A eventData) {
@@ -48,6 +51,7 @@ public class EventDataBuilder {
 
     /**
      * Configures an event data builder to host a JSON payload.
+     *
      * @param eventType event's type.
      * @param eventData event's payload.
      * @return an event data builder.
@@ -55,25 +59,22 @@ public class EventDataBuilder {
     public static EventDataBuilder json(String eventType, byte[] eventData) {
         return json(null, eventType, eventData);
     }
+
     /**
      * Configures an event data builder to host a JSON payload.
-     * @param id event's id.
+     *
+     * @param id        event's id.
      * @param eventType event's type.
      * @param eventData event's payload.
      * @return an event data builder.
      */
     public static EventDataBuilder json(UUID id, String eventType, byte[] eventData) {
-        EventDataBuilder self = new EventDataBuilder();
-        self.eventData = eventData;
-        self.eventType = eventType;
-        self.isJson = true;
-        self.id = id;
-
-        return self;
+        return binary(id, eventType, eventData, true);
     }
 
     /**
      * Configures an event data builder to host a binary payload.
+     *
      * @param eventType event's type.
      * @param eventData event's payload.
      * @return an event data builder.
@@ -84,17 +85,31 @@ public class EventDataBuilder {
 
     /**
      * Configures an event data builder to host a binary payload.
-     * @param id event's id.
+     *
+     * @param id        event's id.
      * @param eventType event's type.
      * @param eventData event's payload.
      * @return an event data builder.
      */
     public static EventDataBuilder binary(UUID id, String eventType, byte[] eventData) {
+        return binary(id, eventType, eventData, false);
+    }
+
+    /**
+     * Configures an event data builder to host a binary payload.
+     *
+     * @param id        event's id.
+     * @param eventType event's type.
+     * @param eventData event's payload.
+     * @param isJson    whether the payload is JSON or not.
+     * @return an event data builder.
+     */
+    public static EventDataBuilder binary(UUID id, String eventType, byte[] eventData, boolean isJson) {
         EventDataBuilder self = new EventDataBuilder();
 
         self.eventData = eventData;
         self.eventType = eventType;
-        self.isJson = false;
+        self.isJson = isJson;
         self.id = id;
 
         return self;
@@ -110,6 +125,7 @@ public class EventDataBuilder {
 
     /**
      * Sets event's custom user metadata.
+     *
      * @param <A> an object that can be serialized in JSON.
      */
     @Deprecated
@@ -134,11 +150,12 @@ public class EventDataBuilder {
 
     /**
      * Builds an event ready to be sent to EventStoreDB.
+     *
      * @see EventData
      */
     public EventData build() {
         UUID eventId = this.id == null ? UUID.randomUUID() : this.id;
-        String contentType = this.isJson ? "application/json" : "application/octet-stream";
+        String contentType = this.isJson ? ContentType.JSON : ContentType.OCTET_STREAM;
         return new EventData(eventId, this.eventType, contentType, this.eventData, this.metadata);
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventDataBuilder.java
@@ -15,16 +15,14 @@ public class EventDataBuilder {
     private boolean isJson;
     private UUID id;
 
-    EventDataBuilder() {
-    }
+    EventDataBuilder(){}
 
     /**
      * Configures builder to serialize event data as JSON.
-     *
      * @param eventType event's type.
      * @param eventData event's payload.
-     * @param <A>       a type that can be serialized in JSON.
      * @return an event data builder.
+     * @param <A> a type that can be serialized in JSON.
      */
     public static <A> EventDataBuilder json(String eventType, A eventData) {
         return json(null, eventType, eventData);
@@ -32,12 +30,11 @@ public class EventDataBuilder {
 
     /**
      * Configures an event data builder to host a JSON payload.
-     *
-     * @param id        event's id.
+     * @param id event's id.
      * @param eventType event's type.
      * @param eventData event's payload.
-     * @param <A>       a type that can be serialized in JSON.
      * @return an event data builder.
+     * @param <A> a type that can be serialized in JSON.
      */
     @Deprecated
     public static <A> EventDataBuilder json(UUID id, String eventType, A eventData) {
@@ -51,7 +48,6 @@ public class EventDataBuilder {
 
     /**
      * Configures an event data builder to host a JSON payload.
-     *
      * @param eventType event's type.
      * @param eventData event's payload.
      * @return an event data builder.
@@ -62,8 +58,7 @@ public class EventDataBuilder {
 
     /**
      * Configures an event data builder to host a JSON payload.
-     *
-     * @param id        event's id.
+     * @param id event's id.
      * @param eventType event's type.
      * @param eventData event's payload.
      * @return an event data builder.
@@ -74,7 +69,6 @@ public class EventDataBuilder {
 
     /**
      * Configures an event data builder to host a binary payload.
-     *
      * @param eventType event's type.
      * @param eventData event's payload.
      * @return an event data builder.
@@ -85,8 +79,7 @@ public class EventDataBuilder {
 
     /**
      * Configures an event data builder to host a binary payload.
-     *
-     * @param id        event's id.
+     * @param id event's id.
      * @param eventType event's type.
      * @param eventData event's payload.
      * @return an event data builder.
@@ -97,11 +90,10 @@ public class EventDataBuilder {
 
     /**
      * Configures an event data builder to host a binary payload.
-     *
-     * @param id        event's id.
+     * @param id event's id.
      * @param eventType event's type.
      * @param eventData event's payload.
-     * @param isJson    whether the payload is JSON or not.
+     * @param isJson whether the payload is JSON or not.
      * @return an event data builder.
      */
     public static EventDataBuilder binary(UUID id, String eventType, byte[] eventData, boolean isJson) {
@@ -125,7 +117,6 @@ public class EventDataBuilder {
 
     /**
      * Sets event's custom user metadata.
-     *
      * @param <A> an object that can be serialized in JSON.
      */
     @Deprecated

--- a/db-client-java/src/main/java/com/eventstore/dbclient/WorkItemArgs.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/WorkItemArgs.java
@@ -49,7 +49,7 @@ class WorkItemArgs {
     public <A> HttpURLConnection getHttpConnection(OptionsBase<A> options, EventStoreDBClientSettings settings, String path) {
         try {
             HttpURLConnection conn = (HttpURLConnection) getURL(settings.isTls(), this.endpoint, path).openConnection();
-            conn.setRequestProperty("Accept", "application/json");
+            conn.setRequestProperty("Accept", ContentType.JSON);
             String creds = options.getHttpCredentialString();
 
             if (creds == null && settings.getDefaultCredentials() != null) {

--- a/db-client-java/src/test/java/com/eventstore/dbclient/TelemetryTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/TelemetryTests.java
@@ -3,6 +3,7 @@ package com.eventstore.dbclient;
 import com.eventstore.dbclient.telemetry.PersistentSubscriptionsTracingInstrumentationTests;
 import com.eventstore.dbclient.telemetry.SpanProcessorSpy;
 import com.eventstore.dbclient.telemetry.StreamsTracingInstrumentationTests;
+import com.eventstore.dbclient.telemetry.TracingContextInjectionTests;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -20,7 +21,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-public class TelemetryTests implements StreamsTracingInstrumentationTests, PersistentSubscriptionsTracingInstrumentationTests {
+public class TelemetryTests implements StreamsTracingInstrumentationTests, PersistentSubscriptionsTracingInstrumentationTests, TracingContextInjectionTests {
     static private Database database;
     static private Logger logger;
 

--- a/db-client-java/src/test/java/com/eventstore/dbclient/telemetry/TracingContextInjectionTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/telemetry/TracingContextInjectionTests.java
@@ -1,0 +1,69 @@
+package com.eventstore.dbclient.telemetry;
+
+import com.eventstore.dbclient.*;
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public interface TracingContextInjectionTests extends TelemetryAware {
+    @Test
+    @Timeout(value = 2, unit = TimeUnit.MINUTES)
+    default void testTracingContextInjectionDoesNotAffectEventBody() throws Throwable {
+        EventStoreDBClient streamsClient = getDefaultClient();
+        EventStoreDBPersistentSubscriptionsClient psClient = getDefaultPersistentSubscriptionClient();
+
+        String streamName = generateName();
+        String groupName = "aGroup";
+
+        EventData[] events = {
+                EventData.builderAsJson("JsonEvent", mapper.writeValueAsBytes(new Foo()))
+                        .eventId(UUID.randomUUID())
+                        .build(),
+                EventData.builderAsBinary("ProtoEvent", mapper.writeValueAsBytes(new Foo()))
+                        .eventId(UUID.randomUUID())
+                        .build()
+        };
+
+        Exceptions exceptions = new Exceptions().registerGoAwayError();
+        flaky(10, exceptions, () -> psClient.createToStream(streamName, groupName).get());
+
+        streamsClient.appendToStream(streamName, events).get();
+
+        CountDownLatch subscribeSpansLatch = new CountDownLatch(events.length);
+        onOperationSpanEnded(ClientTelemetryConstants.Operations.SUBSCRIBE, span -> subscribeSpansLatch.countDown());
+
+        ArrayList<RecordedEvent> receivedEvents = new ArrayList<>();
+        PersistentSubscription subscription = psClient.subscribeToStream(
+                streamName,
+                groupName,
+                SubscribePersistentSubscriptionOptions.get().bufferSize(32),
+                new PersistentSubscriptionListener() {
+                    @Override
+                    public void onEvent(PersistentSubscription subscription, int retryCount, ResolvedEvent event) {
+                        receivedEvents.add(event.getEvent());
+                    }
+                }
+        ).get();
+
+        subscribeSpansLatch.await();
+        subscription.stop();
+
+        for (RecordedEvent receivedEvent : receivedEvents) {
+            EventData sentEvent = Arrays.stream(events)
+                    .filter(e -> e.getEventId().equals(receivedEvent.getEventId()))
+                    .findFirst()
+                    .orElse(null);
+
+            Assertions.assertNotNull(sentEvent);
+            Assertions.assertArrayEquals(sentEvent.getEventData(), receivedEvent.getEventData());
+            Assertions.assertEquals(sentEvent.getContentType(), receivedEvent.getContentType());
+        }
+    }
+}


### PR DESCRIPTION
Updated: Fixed bug in the ClientTelemetry whereby injection logic forces all events to have JSON content type.

Fixes #280 