### PR TITLE
Extract tracing metadata from Event not OriginalEvent

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRegularSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractRegularSubscription.java
@@ -113,7 +113,7 @@ abstract class AbstractRegularSubscription {
                                 channel,
                                 client.getSettings(),
                                 options.getCredentials(),
-                                resolvedEvent.getOriginalEvent());
+                                resolvedEvent.getEvent());
                     } catch (Exception e) {
                         onError(e);
                     }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/AbstractSubscribePersistentSubscription.java
@@ -98,7 +98,7 @@ abstract class AbstractSubscribePersistentSubscription {
                                     args.getChannel(),
                                     client.getSettings(),
                                     options.getCredentials(),
-                                    resolvedEvent.getOriginalEvent());
+                                    resolvedEvent.getEvent());
                         } catch (Exception e) {
                             onError(e);
                         }


### PR DESCRIPTION
Changed: Extract tracing metadata from Event 

We were previously extracting trace context from the OriginalEvent. This means we will not be able to extract the trace information when consuming events from a category stream. This PR extracts the trace information from the Event itself. This applies to both regular and persistent subscriptions.

Also improved test `testTracingContextInjectionIsIgnoredAsExpectedWhenUserMetadataIsNonNullAndNotAJsonObject` to ensure no span is created in subscription for events with non-json metadata.