### PR TITLE
Add support for direct DNS lookups behind a feature flag.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ClientFeatureFlags.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ClientFeatureFlags.java
@@ -1,0 +1,10 @@
+package com.eventstore.dbclient;
+
+public final class ClientFeatureFlags {
+    /**
+     * Enables direct DNS name resolution, retrieving all IP addresses associated with a given hostname. This
+     * functionality was initially implemented to support the now-deprecated TCP API. It is particularly useful in
+     * scenarios involving clusters, where node discovery is enabled.
+     */
+    public static final String DNS_LOOKUP = "dns-lookup";
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ConnectionSettingsBuilder.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ConnectionSettingsBuilder.java
@@ -31,6 +31,7 @@ public class ConnectionSettingsBuilder {
     private Long _defaultDeadline = null;
     private List<ClientInterceptor> _interceptors = new ArrayList<>();
     private String _tlsCaFile = null;
+    private Set<String> _features = new HashSet<>();
 
     ConnectionSettingsBuilder() {}
 
@@ -54,7 +55,8 @@ public class ConnectionSettingsBuilder {
                 _keepAliveInterval,
                 _defaultDeadline,
                 _interceptors,
-                _tlsCaFile);
+                _tlsCaFile,
+                _features);
     }
 
     /**
@@ -216,6 +218,22 @@ public class ConnectionSettingsBuilder {
      */
     public ConnectionSettingsBuilder tlsCaFile(String filepath) {
         this._tlsCaFile = filepath;
+        return this;
+    }
+
+    /**
+     * Add feature flags.
+     */
+    public ConnectionSettingsBuilder features(String... features) {
+        this._features.addAll(Arrays.asList(features));
+        return this;
+    }
+
+    /**
+     * Add feature flag.
+     */
+    public ConnectionSettingsBuilder feature(String feature) {
+        this._features.add(feature);
         return this;
     }
 
@@ -434,6 +452,10 @@ public class ConnectionSettingsBuilder {
                         invalidParamFormat(entry[0], entry[1]);
 
                     userKeyFile = entry[1];
+                    break;
+
+                case "feature":
+                    builder._features.add(value);
                     break;
 
                 default:

--- a/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClientSettings.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBClientSettings.java
@@ -4,6 +4,7 @@ import io.grpc.ClientInterceptor;
 
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Gathers all the settings related to a gRPC client with an EventStoreDB database.
@@ -39,6 +40,7 @@ public class EventStoreDBClientSettings {
     private final Long defaultDeadline;
     private final List<ClientInterceptor> interceptors;
     private final String tlsCaFile;
+    private final Set<String> features;
 
     /**
      * If the dns discovery is enabled.
@@ -160,6 +162,11 @@ public class EventStoreDBClientSettings {
         return tlsCaFile;
     }
 
+    /**
+     * Feature flags
+     */
+    public Set<String> getFeatures() { return features; }
+
     EventStoreDBClientSettings(
             boolean dnsDiscover,
             int maxDiscoverAttempts,
@@ -175,7 +182,8 @@ public class EventStoreDBClientSettings {
             long keepAliveInterval,
             Long defaultDeadline,
             List<ClientInterceptor> interceptors,
-            String tlsCaFile
+            String tlsCaFile,
+            Set<String> features
     ) {
         this.dnsDiscover = dnsDiscover;
         this.maxDiscoverAttempts = maxDiscoverAttempts;
@@ -192,6 +200,7 @@ public class EventStoreDBClientSettings {
         this.defaultDeadline = defaultDeadline;
         this.interceptors = interceptors;
         this.tlsCaFile = tlsCaFile;
+        this.features = features;
     }
 
     /**

--- a/db-client-java/src/main/java/com/eventstore/dbclient/resolution/DeferredNodeResolution.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/resolution/DeferredNodeResolution.java
@@ -1,0 +1,18 @@
+package com.eventstore.dbclient.resolution;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+
+public class DeferredNodeResolution implements NodeResolution {
+    private final InetSocketAddress address;
+
+    public DeferredNodeResolution(InetSocketAddress address) {
+        this.address = address;
+    }
+
+    @Override
+    public List<InetSocketAddress> resolve() {
+        return Collections.singletonList(address);
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/resolution/DeprecatedNodeResolution.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/resolution/DeprecatedNodeResolution.java
@@ -1,0 +1,27 @@
+package com.eventstore.dbclient.resolution;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DeprecatedNodeResolution implements NodeResolution {
+    private final InetSocketAddress address;
+
+    public DeprecatedNodeResolution(InetSocketAddress address) {
+        this.address = address;
+    }
+
+    @Override
+    public List<InetSocketAddress> resolve() {
+        try {
+            return Arrays.stream(InetAddress.getAllByName(address.getHostName()))
+                    .map(addr -> new InetSocketAddress(addr, address.getPort()))
+                    .collect(Collectors.toList());
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/resolution/FixedSeedsNodeResolution.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/resolution/FixedSeedsNodeResolution.java
@@ -1,0 +1,18 @@
+package com.eventstore.dbclient.resolution;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
+
+public class FixedSeedsNodeResolution implements NodeResolution {
+    private final InetSocketAddress[] seeds;
+
+    public FixedSeedsNodeResolution(InetSocketAddress[] seeds) {
+        this.seeds = seeds;
+    }
+
+    @Override
+    public List<InetSocketAddress> resolve() {
+        return Arrays.asList(seeds);
+    }
+}

--- a/db-client-java/src/main/java/com/eventstore/dbclient/resolution/NodeResolution.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/resolution/NodeResolution.java
@@ -1,0 +1,8 @@
+package com.eventstore.dbclient.resolution;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+public interface NodeResolution {
+    List<InetSocketAddress> resolve();
+}

--- a/db-client-java/src/test/java/com/eventstore/dbclient/misc/ParseValidConnectionStringTests.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/misc/ParseValidConnectionStringTests.java
@@ -110,6 +110,14 @@ public class ParseValidConnectionStringTests {
                 Arguments.of(
                         "esdb://127.0.0.1:21573?userCertFile=/path/to/cert&userKeyFile=/path/to/key",
                         "{\"dnsDiscover\":false,\"maxDiscoverAttempts\":3,\"discoveryInterval\":500,\"gossipTimeout\":3000,\"nodePreference\":\"leader\",\"tls\":true,\"tlsVerifyCert\":true,\"throwOnAppendFailure\":true,\"hosts\":[{\"address\":\"127.0.0.1\",\"port\":21573}], \"defaultClientCertificate\": {\"clientCertFile\": \"/path/to/cert\", \"clientKeyFile\": \"/path/to/key\"}}"
+                ),
+                Arguments.of(
+                        "esdb://localhost?feature=foobar",
+                        "{\"dnsDiscover\":false,\"maxDiscoverAttempts\":3,\"discoveryInterval\":500,\"gossipTimeout\":3000,\"nodePreference\":\"leader\",\"tls\":true,\"tlsVerifyCert\":true,\"throwOnAppendFailure\":true,\"hosts\":[{\"address\":\"localhost\",\"port\":2113}], \"features\": \"foobar\"}"
+                ),
+                Arguments.of(
+                        "esdb://localhost?feature=foobar&feature=baz",
+                        "{\"dnsDiscover\":false,\"maxDiscoverAttempts\":3,\"discoveryInterval\":500,\"gossipTimeout\":3000,\"nodePreference\":\"leader\",\"tls\":true,\"tlsVerifyCert\":true,\"throwOnAppendFailure\":true,\"hosts\":[{\"address\":\"localhost\",\"port\":2113}], \"features\": [\"foobar\", \"baz\"]}"
                 )
         );
     }
@@ -214,6 +222,15 @@ public class ParseValidConnectionStringTests {
         tree.get("hosts").elements().forEachRemaining((host) -> {
             builder.addHost(new InetSocketAddress(host.get("address").asText(), host.get("port").asInt()));
         });
+
+        if (tree.get("features") != null) {
+           JsonNode features = tree.get("features");
+
+           if (features.isArray())
+               features.elements().forEachRemaining(feature -> builder.feature(feature.asText()));
+           else
+               builder.feature(features.asText());
+        }
 
         return builder.buildConnectionSettings();
     }


### PR DESCRIPTION
Added: Add support for direct DNS lookups behind a feature flag.

Fixes #273 

### description

With this feature, the client will directly perform DNS lookups when probing for candidates during the connection process to a cluster of nodes. This mirrors the behavior from when the TCP API was still supported.

You can enable that feature using a connection string or a the connection builder.

### connection string

```
esdb+discover://my.esdbcluster.com:1234?feature=dns-lookup
```

### connection builder

```java
     EventStoreDBClientSettings.builder()
        .dnsDiscover(true)
        .addHost("my.esdbcluster.com", 1234)
        .feature("dns-lookup")
        .buildConnectionSettings()
```
