### PR TITLE
Support custom headers.

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ConnectionMetadata.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ConnectionMetadata.java
@@ -2,6 +2,8 @@ package com.eventstore.dbclient;
 
 import io.grpc.Metadata;
 
+import java.util.Map;
+
 class ConnectionMetadata {
     private Metadata metadata;
 
@@ -24,6 +26,13 @@ class ConnectionMetadata {
 
     public ConnectionMetadata requiresLeader() {
         this.metadata.put(Metadata.Key.of("requires-leader", Metadata.ASCII_STRING_MARSHALLER), String.valueOf(true));
+        return this;
+    }
+
+    public ConnectionMetadata headers(Map<String, String> headers) {
+        for (Map.Entry<String, String> entry : headers.entrySet())
+            this.metadata.put(Metadata.Key.of(entry.getKey(), Metadata.ASCII_STRING_MARSHALLER), entry.getValue());
+
         return this;
     }
 

--- a/db-client-java/src/main/java/com/eventstore/dbclient/GrpcUtils.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/GrpcUtils.java
@@ -150,6 +150,8 @@ final class GrpcUtils {
             metadata.requiresLeader();
         }
 
+        metadata.headers(options.getHeaders());
+
         return finalStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata.build()));
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/OptionsBase.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/OptionsBase.java
@@ -1,10 +1,14 @@
 package com.eventstore.dbclient;
 
+import java.util.HashMap;
+import java.util.Map;
+
 class OptionsBase<T> {
     private Long deadline;
     private final OperationKind kind;
     private UserCredentials credentials;
     private boolean requiresLeader;
+    private Map<String, String> headers = new HashMap<>();
 
     protected OptionsBase() {
         this(OperationKind.Regular);
@@ -83,6 +87,15 @@ class OptionsBase<T> {
         return (T)this;
     }
 
+    /**
+     * Adds a custom HTTP header that will be added to the request.
+     */
+    @SuppressWarnings("unchecked")
+    public T header(String key, String value) {
+        headers.put(key, value);
+        return (T)this;
+    }
+
     Long getDeadline() {
         return deadline;
     }
@@ -97,5 +110,9 @@ class OptionsBase<T> {
 
     UserCredentials getCredentials() {
         return this.credentials;
+    }
+
+    Map<String, String> getHeaders() {
+        return this.headers;
     }
 }


### PR DESCRIPTION
Added: Support custom headers.

Fixes #286 

Now, you can add custom headers at request options level:

```java
 AppendToStreamOptions options = AppendToStreamOptions.get()
                .expectedRevision(ExpectedRevision.noStream())
                .header("header1", "value1")
                .header("header2", "value2");
```
