### PR TITLE
Disable trace context extraction for deleted events

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ClientTelemetry.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ClientTelemetry.java
@@ -122,6 +122,11 @@ class ClientTelemetry {
     static void traceSubscribe(Runnable tracedOperation, String subscriptionId, ManagedChannel channel,
                                EventStoreDBClientSettings settings,
                                UserCredentials optionalCallCredentials, RecordedEvent event) {
+        if (event == null) {
+            tracedOperation.run();
+            return;
+        }
+
         SpanContext remoteParentContext = tryExtractTracingContext(event.getUserMetadata());
 
         if (remoteParentContext == null) {

--- a/db-client-java/src/test/java/com/eventstore/dbclient/databases/DockerContainerDatabase.java
+++ b/db-client-java/src/test/java/com/eventstore/dbclient/databases/DockerContainerDatabase.java
@@ -74,6 +74,7 @@ public class DockerContainerDatabase extends GenericContainer<DockerContainerDat
         addExposedPorts(1113, 2113);
 
         withEnv("EVENTSTORE_RUN_PROJECTIONS", "ALL");
+        withEnv("EVENTSTORE_START_STANDARD_PROJECTIONS", "true");
         withEnv("EVENTSTORE_ENABLE_ATOM_PUB_OVER_HTTP", "true");
 
         if (builder.secure) {


### PR DESCRIPTION
Fixed: Disable trace context extraction for deleted events
Fixes: #291