### PR TITLE
Filtered reads

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadAll.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadAll.java
@@ -33,10 +33,16 @@ class ReadAll extends AbstractRead {
                 .setResolveLinks(this.options.shouldResolveLinkTos())
                 .setControlOption(StreamsOuterClass.ReadReq.Options.ControlOption.newBuilder().setCompatibility(1))
                 .setCount(this.options.getMaxCount())
-                .setNoFilter(Shared.Empty.getDefaultInstance())
+                //.setNoFilter(Shared.Empty.getDefaultInstance())
                 .setReadDirection(this.options.getDirection() == Direction.Forwards ?
                         StreamsOuterClass.ReadReq.Options.ReadDirection.Forwards :
                         StreamsOuterClass.ReadReq.Options.ReadDirection.Backwards);
+
+        if (this.options.getFilter() != null) {
+            this.options.getFilter().addToWireStreamsReadReq(builder);
+        } else {
+            builder.setNoFilter(Shared.Empty.getDefaultInstance());
+        }
 
         return builder;
     }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadAllOptions.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadAllOptions.java
@@ -4,6 +4,7 @@ package com.eventstore.dbclient;
  * Options of the read $all stream request.
  */
 public class ReadAllOptions extends OptionsWithPositionAndResolveLinkTosBase<ReadAllOptions> {
+    private SubscriptionFilter filter;
     private Direction direction;
     private long maxCount;
 
@@ -55,6 +56,18 @@ public class ReadAllOptions extends OptionsWithPositionAndResolveLinkTosBase<Rea
      */
     public ReadAllOptions maxCount(long maxCount) {
         this.maxCount = maxCount;
+        return this;
+    }
+
+    SubscriptionFilter getFilter() {
+        return filter;
+    }
+
+    /**
+     * Applies a server-side filter to determine if an event of the read should be yielded.
+     */
+    public ReadAllOptions filter(SubscriptionFilter filter) {
+        this.filter = filter;
         return this;
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadStream.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadStream.java
@@ -20,14 +20,21 @@ class ReadStream extends AbstractRead {
 
     @Override
     public StreamsOuterClass.ReadReq.Options.Builder createOptions() {
-        return defaultReadOptions.clone()
+        StreamsOuterClass.ReadReq.Options.Builder optionsBuilder =
+            defaultReadOptions.clone()
                 .setStream(GrpcUtils.toStreamOptions(this.streamName, this.options.getStartingRevision()))
                 .setResolveLinks(this.options.shouldResolveLinkTos())
                 .setCount(this.options.getMaxCount())
                 .setControlOption(StreamsOuterClass.ReadReq.Options.ControlOption.newBuilder().setCompatibility(1))
-                .setNoFilter(Shared.Empty.getDefaultInstance())
+                //.setNoFilter(Shared.Empty.getDefaultInstance())
                 .setReadDirection(this.options.getDirection() == Direction.Forwards ?
                         StreamsOuterClass.ReadReq.Options.ReadDirection.Forwards :
                         StreamsOuterClass.ReadReq.Options.ReadDirection.Backwards);
+        if (this.options.getFilter() != null) {
+            this.options.getFilter().addToWireStreamsReadReq(optionsBuilder);
+        } else {
+            optionsBuilder.setNoFilter(Shared.Empty.getDefaultInstance());
+        }
+        return optionsBuilder;
     }
 }

--- a/db-client-java/src/main/java/com/eventstore/dbclient/ReadStreamOptions.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/ReadStreamOptions.java
@@ -4,6 +4,7 @@ package com.eventstore.dbclient;
  * Options of the read stream request.
  */
 public class ReadStreamOptions extends OptionsWithStartRevisionAndResolveLinkTosBase<ReadStreamOptions> {
+    private SubscriptionFilter filter;
     private Direction direction;
     private long maxCount;
 
@@ -58,6 +59,18 @@ public class ReadStreamOptions extends OptionsWithStartRevisionAndResolveLinkTos
      */
     public ReadStreamOptions maxCount(long maxCount) {
         this.maxCount = maxCount;
+        return this;
+    }
+
+    SubscriptionFilter getFilter() {
+        return filter;
+    }
+
+    /**
+     * Applies a server-side filter to determine if an event of the read should be yielded.
+     */
+    public ReadStreamOptions filter(SubscriptionFilter filter) {
+        this.filter = filter;
         return this;
     }
 }


### PR DESCRIPTION
Added: Allow the caller to specify a filter upon reading a stream (including `$all`).