### PR TITLE
Unwrap CompletionException in GrpcClient

### DIFF
--- a/db-client-java/src/main/java/com/eventstore/dbclient/GrpcClient.java
+++ b/db-client-java/src/main/java/com/eventstore/dbclient/GrpcClient.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -78,6 +79,10 @@ class GrpcClient {
         return getWorkItemArgs().thenComposeAsync((args) -> {
             return action.apply(args).handleAsync((outcome, e) -> {
                 if (e != null) {
+                    if (e instanceof CompletionException) {
+                        e = e.getCause();
+                    }
+
                     if (e instanceof NotLeaderException) {
                         NotLeaderException ex = (NotLeaderException) e;
                         // TODO - Currently we don't retry on not leader exception but we might consider


### PR DESCRIPTION
GrpcClient expects Exceptions of a specific type but as it is right now it will not handle any exceptions as they are propagated as CompletionException

This will not solve any similar issues for any other class using ClientTelemetry, and a better solution would probably be to never wrap the exception, however that would require more intrusive changes to the future chain.

Fixes #297 