### PR TITLE
Update bouncycastle libs from 1.77 to 1.80

### DIFF
--- a/db-client-java/build.gradle
+++ b/db-client-java/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     implementation 'org.slf4j:slf4j-api:2.0.9'
-    implementation "org.bouncycastle:bcprov-jdk18on:1.77"
-    implementation "org.bouncycastle:bcpkix-jdk18on:1.77"
+    implementation "org.bouncycastle:bcprov-jdk18on:1.80"
+    implementation "org.bouncycastle:bcpkix-jdk18on:1.80"
 
     implementation platform("io.opentelemetry:opentelemetry-bom:${openTelemetryVersion}")
     implementation "io.opentelemetry:opentelemetry-api"


### PR DESCRIPTION
Update bouncycastle libs to 1.80
### Motivation
Versions below 1.78 contains vulnerabilities reported.

This pull request includes a version update for Bouncy Castle dependencies in the `db-client-java` project. The change ensures that the project uses the latest stable versions of these libraries.

Dependency updates:

* [`db-client-java/build.gradle`](diffhunk://#diff-f6dcd9f2357471eabad4710f6c12df173bb88ae21ac495484355debc3b7504e8L50-R51): Updated `org.bouncycastle:bcprov-jdk18on` and `org.bouncycastle:bcpkix-jdk18on` from version 1.77 to 1.80.