### PR TITLE
docs: correct article usage with "Kurrent" 

### DIFF
--- a/src/main/java/io/kurrent/dbclient/KurrentDBClientSettings.java
+++ b/src/main/java/io/kurrent/dbclient/KurrentDBClientSettings.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Gathers all the settings related to a gRPC client with an KurrentDB database.
+ * Gathers all the settings related to a gRPC client with a KurrentDB database.
  * <i>EventStoreDBClientSettings}</i> can only be created when parsing a connection string.
  *
  * <i>KurrentDBClientSettings</i> supports a wide range of settings. If a setting is not mentioned in the connection


### PR DESCRIPTION
This PR addresses grammatical issues that occurred during the rebranding from "Event Store" to "Kurrent". The main issue was incorrect article usage - using "an KurrentDB" instead of "a KurrentDB" since "Kurrent" starts with a consonant sound.