### PR TITLE
fix: fix eager name resolution

### DIFF
--- a/src/main/java/io/kurrent/dbclient/ClientTelemetryTags.java
+++ b/src/main/java/io/kurrent/dbclient/ClientTelemetryTags.java
@@ -36,9 +36,9 @@ class ClientTelemetryTags extends HashMap<String, String> {
         Builder withServerTagsFromClientSettings(KurrentDBClientSettings settings) {
             if (settings == null || !settings.isDnsDiscover()) return this;
 
-            InetSocketAddress dns = settings.getHosts()[0];
+            Endpoint dns = settings.getHosts()[0];
 
-            return withServerTags(dns.getAddress().toString(), String.valueOf(dns.getPort()));
+            return withServerTags(dns.getHost(), String.valueOf(dns.getPort()));
         }
 
         private Builder withServerTags(String address, String port) {

--- a/src/main/java/io/kurrent/dbclient/ConnectionSettingsBuilder.java
+++ b/src/main/java/io/kurrent/dbclient/ConnectionSettingsBuilder.java
@@ -29,7 +29,7 @@ public class ConnectionSettingsBuilder {
     private boolean _tlsVerifyCert = true;
     private UserCredentials _defaultCredentials;
     private ClientCertificate _defaultClientCertificate;
-    private LinkedList<InetSocketAddress> _hosts = new LinkedList<>();
+    private LinkedList<Endpoint> _hosts = new LinkedList<>();
     private long _keepAliveTimeout = Consts.DEFAULT_KEEP_ALIVE_TIMEOUT_IN_MS;
     private long _keepAliveInterval = Consts.DEFAULT_KEEP_ALIVE_INTERVAL_IN_MS;
     private Long _defaultDeadline = null;
@@ -54,7 +54,7 @@ public class ConnectionSettingsBuilder {
                 _tlsVerifyCert,
                 _defaultCredentials,
                 _defaultClientCertificate,
-                _hosts.toArray(new InetSocketAddress[0]),
+                _hosts.toArray(new Endpoint[0]),
                 _keepAliveTimeout,
                 _keepAliveInterval,
                 _defaultDeadline,
@@ -155,14 +155,15 @@ public class ConnectionSettingsBuilder {
      * Adds an endpoint the client will use to connect.
      */
     public ConnectionSettingsBuilder addHost(String host, int port) {
-        return addHost(new InetSocketAddress(host, port));
+        this._hosts.add(new Endpoint(host, port));
+        return this;
     }
 
     /**
      * Adds an endpoint the client will use to connect.
      */
     public ConnectionSettingsBuilder addHost(InetSocketAddress host) {
-        this._hosts.push(host);
+        this._hosts.push(new Endpoint(host.getHostName(), host.getPort()));
         return this;
     }
 

--- a/src/main/java/io/kurrent/dbclient/Endpoint.java
+++ b/src/main/java/io/kurrent/dbclient/Endpoint.java
@@ -1,0 +1,19 @@
+package io.kurrent.dbclient;
+
+public class Endpoint {
+    private final String host;
+    private final int port;
+
+    public Endpoint(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+}

--- a/src/main/java/io/kurrent/dbclient/KurrentDBClientSettings.java
+++ b/src/main/java/io/kurrent/dbclient/KurrentDBClientSettings.java
@@ -34,7 +34,7 @@ public class KurrentDBClientSettings {
     private final boolean tlsVerifyCert;
     private final UserCredentials defaultCredentials;
     private final ClientCertificate defaultClientCertificate;
-    private final InetSocketAddress[] hosts;
+    private final Endpoint[] hosts;
     private final long keepAliveTimeout;
     private final long keepAliveInterval;
     private final Long defaultDeadline;
@@ -117,7 +117,7 @@ public class KurrentDBClientSettings {
      * The list of endpoints that the client uses to connect.
      * @return hosts to connect to.
      */
-    public InetSocketAddress[] getHosts() {
+    public Endpoint[] getHosts() {
         return hosts;
     }
 
@@ -177,7 +177,7 @@ public class KurrentDBClientSettings {
             boolean tlsVerifyCert,
             UserCredentials defaultCredentials,
             ClientCertificate defaultClientCertificate,
-            InetSocketAddress[] hosts,
+            Endpoint[] hosts,
             long keepAliveTimeout,
             long keepAliveInterval,
             Long defaultDeadline,

--- a/src/main/java/io/kurrent/dbclient/SingleNodeDiscovery.java
+++ b/src/main/java/io/kurrent/dbclient/SingleNodeDiscovery.java
@@ -4,14 +4,14 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 
 class SingleNodeDiscovery implements Discovery {
-    private final InetSocketAddress endpoint;
+    private final Endpoint endpoint;
 
-    SingleNodeDiscovery(InetSocketAddress endpoint) {
+    SingleNodeDiscovery(Endpoint endpoint) {
         this.endpoint = endpoint;
     }
 
     @Override
     public CompletableFuture<Void> run(ConnectionState state) {
-        return CompletableFuture.runAsync(() -> state.connect(endpoint));
+        return CompletableFuture.runAsync(() -> state.connect(new InetSocketAddress(this.endpoint.getHost(), this.endpoint.getPort())));
     }
 }

--- a/src/main/java/io/kurrent/dbclient/resolution/DeferredNodeResolution.java
+++ b/src/main/java/io/kurrent/dbclient/resolution/DeferredNodeResolution.java
@@ -1,18 +1,20 @@
 package io.kurrent.dbclient.resolution;
 
+import io.kurrent.dbclient.Endpoint;
+
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 
 public class DeferredNodeResolution implements NodeResolution {
-    private final InetSocketAddress address;
+    private final Endpoint address;
 
-    public DeferredNodeResolution(InetSocketAddress address) {
+    public DeferredNodeResolution(Endpoint address) {
         this.address = address;
     }
 
     @Override
     public List<InetSocketAddress> resolve() {
-        return Collections.singletonList(address);
+        return Collections.singletonList(new InetSocketAddress(address.getHost(), address.getPort()));
     }
 }

--- a/src/main/java/io/kurrent/dbclient/resolution/DeprecatedNodeResolution.java
+++ b/src/main/java/io/kurrent/dbclient/resolution/DeprecatedNodeResolution.java
@@ -1,5 +1,7 @@
 package io.kurrent.dbclient.resolution;
 
+import io.kurrent.dbclient.Endpoint;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -8,16 +10,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class DeprecatedNodeResolution implements NodeResolution {
-    private final InetSocketAddress address;
+    private final Endpoint address;
 
-    public DeprecatedNodeResolution(InetSocketAddress address) {
+    public DeprecatedNodeResolution(Endpoint address) {
         this.address = address;
     }
 
     @Override
     public List<InetSocketAddress> resolve() {
         try {
-            return Arrays.stream(InetAddress.getAllByName(address.getHostName()))
+            return Arrays.stream(InetAddress.getAllByName(address.getHost()))
                     .map(addr -> new InetSocketAddress(addr, address.getPort()))
                     .collect(Collectors.toList());
         } catch (UnknownHostException e) {

--- a/src/main/java/io/kurrent/dbclient/resolution/FixedSeedsNodeResolution.java
+++ b/src/main/java/io/kurrent/dbclient/resolution/FixedSeedsNodeResolution.java
@@ -1,18 +1,26 @@
 package io.kurrent.dbclient.resolution;
 
+import io.kurrent.dbclient.Endpoint;
+
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class FixedSeedsNodeResolution implements NodeResolution {
-    private final InetSocketAddress[] seeds;
+    private final Endpoint[] seeds;
 
-    public FixedSeedsNodeResolution(InetSocketAddress[] seeds) {
+    public FixedSeedsNodeResolution(Endpoint[] seeds) {
         this.seeds = seeds;
     }
 
     @Override
     public List<InetSocketAddress> resolve() {
-        return Arrays.asList(seeds);
+        List<InetSocketAddress> addresses = new ArrayList<>(seeds.length);
+
+        for (Endpoint seed : seeds)
+            addresses.add(new InetSocketAddress(seed.getHost(), seed.getPort()));
+
+        return addresses;
     }
 }

--- a/src/test/java/io/kurrent/dbclient/misc/ParseValidConnectionStringTests.java
+++ b/src/test/java/io/kurrent/dbclient/misc/ParseValidConnectionStringTests.java
@@ -145,7 +145,7 @@ public class ParseValidConnectionStringTests {
 
         Assertions.assertEquals(settings.getHosts().length, other.getHosts().length);
         IntStream.range(0, settings.getHosts().length).forEach((i) -> {
-            Assertions.assertEquals(settings.getHosts()[i].getHostName(), other.getHosts()[i].getHostName());
+            Assertions.assertEquals(settings.getHosts()[i].getHost(), other.getHosts()[i].getHost());
             Assertions.assertEquals(settings.getHosts()[i].getPort(), other.getHosts()[i].getPort());
         });
     }
@@ -227,7 +227,7 @@ public class ParseValidConnectionStringTests {
         }
 
         tree.get("hosts").elements().forEachRemaining((host) -> {
-            builder.addHost(new InetSocketAddress(host.get("address").asText(), host.get("port").asInt()));
+            builder.addHost(host.get("address").asText(), host.get("port").asInt());
         });
 
         if (tree.get("features") != null) {


### PR DESCRIPTION
The client was eagerly resolving the IP address of a hostname, which could lead to situations where it repeatedly used the same IP, even though the DNS might have updated it in the meantime.