### PR TITLE
fix: [DEVEX-438] Skip tracing metadata injection when span context is invalid or unsampled

### DIFF
--- a/src/main/java/io/kurrent/dbclient/ClientTelemetry.java
+++ b/src/main/java/io/kurrent/dbclient/ClientTelemetry.java
@@ -29,6 +29,9 @@ class ClientTelemetry {
     }
 
     private static List<EventData> tryInjectTracingContext(Span span, List<EventData> events) {
+        if (!span.getSpanContext().isValid() || !span.getSpanContext().isSampled())
+            return events;
+
         List<EventData> injectedEvents = new ArrayList<>();
         for (EventData event : events) {
             boolean isJsonEvent = Objects.equals(event.getContentType(), ContentType.JSON);

--- a/src/test/java/io/kurrent/dbclient/streams/AppendTests.java
+++ b/src/test/java/io/kurrent/dbclient/streams/AppendTests.java
@@ -1,7 +1,7 @@
 package io.kurrent.dbclient.streams;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.kurrent.dbclient.*;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -11,43 +11,42 @@ public interface AppendTests extends ConnectionAware {
     @Test
     default void testAppendSingleEventNoStream() throws Throwable {
         KurrentDBClient client = getDatabase().defaultClient();
+        String streamName = generateName();
+        String eventType = "TestEvent";
+        UUID eventId = UUID.randomUUID();
+        Foo foo = new Foo();
+        byte[] fooBytes = mapper.writeValueAsBytes(foo);
 
-        final String streamName = generateName();
-        final String eventType = "TestEvent";
-        final String eventId = "38fffbc2-339e-11ea-8c7b-784f43837872";
-        final byte[] eventMetaData = new byte[]{0xd, 0xe, 0xa, 0xd};
-        final JsonMapper jsonMapper = new JsonMapper();
-
-        EventData event = EventData.builderAsJson(eventType, jsonMapper.writeValueAsBytes(new Foo()))
-                .metadataAsBytes(eventMetaData)
-                .eventId(UUID.fromString(eventId))
+        EventData event = EventData.builderAsJson(eventType, fooBytes)
+                .metadataAsBytes(fooBytes)
+                .eventId(eventId)
                 .build();
 
-        AppendToStreamOptions appendOptions = AppendToStreamOptions.get()
-                .streamState(StreamState.noStream());
-
-        WriteResult appendResult = client.appendToStream(streamName, appendOptions, event)
-                .get();
+        WriteResult appendResult = client.appendToStream(
+                streamName,
+                AppendToStreamOptions.get().streamState(StreamState.noStream()),
+                event
+        ).get();
 
         Assertions.assertEquals(StreamState.streamRevision(0), appendResult.getNextExpectedRevision());
 
-        ReadStreamOptions readStreamOptions = ReadStreamOptions.get()
-                .fromEnd()
-                .backwards()
-                .maxCount(1);
-
-        // Ensure appended event is readable
-        ReadResult result = client.readStream(streamName, readStreamOptions)
-                .get();
+        ReadResult result = client.readStream(
+                streamName,
+                ReadStreamOptions.get().fromEnd().backwards().maxCount(1)
+        ).get();
 
         Assertions.assertEquals(1, result.getEvents().size());
         RecordedEvent first = result.getEvents().get(0).getEvent();
-        JsonMapper mapper = new JsonMapper();
+        ObjectNode userMetadata = mapper.readValue(first.getUserMetadata(), ObjectNode.class);
 
-        Assertions.assertEquals(streamName, first.getStreamId());
-        Assertions.assertEquals(eventType, first.getEventType());
-        Assertions.assertEquals(eventId, first.getEventId().toString());
-        Assertions.assertArrayEquals(eventMetaData, first.getUserMetadata());
-        Assertions.assertEquals(new Foo(), mapper.readValue(first.getEventData(), Foo.class));
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(streamName, first.getStreamId()),
+                () -> Assertions.assertEquals(eventType, first.getEventType()),
+                () -> Assertions.assertEquals(eventId.toString(), first.getEventId().toString()),
+                () -> Assertions.assertEquals(foo, mapper.readValue(first.getEventData(), Foo.class)),
+                () -> Assertions.assertEquals(foo, mapper.readValue(first.getUserMetadata(), Foo.class)),
+                () -> Assertions.assertFalse(userMetadata.has(ClientTelemetryConstants.Metadata.TRACE_ID)),
+                () -> Assertions.assertFalse(userMetadata.has(ClientTelemetryConstants.Metadata.SPAN_ID))
+        );
     }
 }


### PR DESCRIPTION
skip ci tests