### PR TITLE
Add tracing for multi stream append

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,8 +84,8 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-simple:2.0.17'
     testImplementation "io.opentelemetry:opentelemetry-sdk"
     testImplementation "io.opentelemetry:opentelemetry-sdk-testing"
-    testImplementation 'io.opentelemetry:opentelemetry-exporter-logging:1.38.0'
-    testImplementation 'io.opentelemetry:opentelemetry-exporter-otlp-trace:1.14.0'
+    testImplementation "io.opentelemetry:opentelemetry-exporter-logging"
+    testImplementation "io.opentelemetry:opentelemetry-exporter-otlp"
 }
 
 tasks.withType(Test).configureEach {

--- a/src/main/java/io/kurrent/dbclient/AppendStreamFailure.java
+++ b/src/main/java/io/kurrent/dbclient/AppendStreamFailure.java
@@ -1,5 +1,7 @@
 package io.kurrent.dbclient;
 
+import io.kurrentdb.protocol.streams.v2.AppendStreamFailure.ErrorCase;
+
 public class AppendStreamFailure {
     private final io.kurrentdb.protocol.streams.v2.AppendStreamFailure inner;
 
@@ -12,21 +14,21 @@ public class AppendStreamFailure {
     }
 
     public void visit(MultiAppendStreamErrorVisitor visitor) {
-        if (this.inner.getErrorCase() == io.kurrentdb.protocol.streams.v2.AppendStreamFailure.ErrorCase.STREAM_REVISION_CONFLICT) {
+        if (this.inner.getErrorCase() == ErrorCase.STREAM_REVISION_CONFLICT) {
             visitor.onWrongExpectedRevision(this.inner.getStreamRevisionConflict().getStreamRevision());
             return;
         }
 
-        if (this.inner.getErrorCase() == io.kurrentdb.protocol.streams.v2.AppendStreamFailure.ErrorCase.ACCESS_DENIED) {
+        if (this.inner.getErrorCase() == ErrorCase.ACCESS_DENIED) {
             visitor.onAccessDenied(this.inner.getAccessDenied());
         }
 
-        if (this.inner.getErrorCase() == io.kurrentdb.protocol.streams.v2.AppendStreamFailure.ErrorCase.STREAM_DELETED) {
+        if (this.inner.getErrorCase() == ErrorCase.STREAM_DELETED) {
             visitor.onStreamDeleted();
             return;
         }
 
-       if (this.inner.getErrorCase() == io.kurrentdb.protocol.streams.v2.AppendStreamFailure.ErrorCase.TRANSACTION_MAX_SIZE_EXCEEDED) {
+       if (this.inner.getErrorCase() == ErrorCase.TRANSACTION_MAX_SIZE_EXCEEDED) {
             visitor.onTransactionMaxSizeExceeded(this.inner.getTransactionMaxSizeExceeded().getMaxSize());
             return;
        }

--- a/src/main/java/io/kurrent/dbclient/ClientTelemetry.java
+++ b/src/main/java/io/kurrent/dbclient/ClientTelemetry.java
@@ -4,15 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.grpc.ManagedChannel;
+import io.kurrentdb.protocol.streams.v2.AppendStreamFailure.ErrorCase;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.*;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
@@ -120,6 +118,104 @@ class ClientTelemetry {
                         }
                     }));
         }
+    }
+
+    static CompletableFuture<MultiAppendWriteResult> traceMultiStreamAppend(
+            BiFunction<WorkItemArgs, Iterator<AppendStreamRequest>, CompletableFuture<MultiAppendWriteResult>> multiAppendOperation,
+            WorkItemArgs args,
+            Iterator<AppendStreamRequest> requests, KurrentDBClientSettings settings) {
+
+        List<AppendStreamRequest> requestsWithTracing = new ArrayList<>();
+        Map<String, Span> spanMap = new HashMap<>();
+
+        while (requests.hasNext()) {
+            AppendStreamRequest request = requests.next();
+
+            Span span = createSpan(
+                    ClientTelemetryConstants.Operations.APPEND,
+                    SpanKind.CLIENT,
+                    null,
+                    ClientTelemetryTags.builder()
+                            .withRequiredTag(ClientTelemetryAttributes.KurrentDB.STREAM, request.getStreamName())
+                            .withServerTagsFromGrpcChannel(args.getChannel())
+                            .withServerTagsFromClientSettings(settings)
+                            .withOptionalDatabaseUserTag(settings.getDefaultCredentials())
+                            .build());
+
+            spanMap.put(request.getStreamName(), span);
+
+            List<EventData> eventsWithTracing = new ArrayList<>();
+            while (request.getEvents().hasNext())
+                eventsWithTracing.add(request.getEvents().next());
+
+            List<EventData> tracedEvents = tryInjectTracingContext(span, eventsWithTracing);
+
+            requestsWithTracing.add(new AppendStreamRequest(
+                    request.getStreamName(),
+                    tracedEvents.iterator(),
+                    request.getExpectedState()
+            ));
+        }
+
+        return multiAppendOperation.apply(args, requestsWithTracing.iterator())
+                .handle((result, throwable) -> {
+                    if (throwable != null) {
+                        for (Span span : spanMap.values()) {
+                            span.setStatus(StatusCode.ERROR);
+                            span.recordException(throwable);
+                            span.end();
+                        }
+                        throw new CompletionException(throwable);
+                    } else {
+                        if (result.getFailures().isPresent()) {
+                            Set<String> processedStreams = new HashSet<>();
+
+                            for (AppendStreamFailure failure : result.getFailures().get()) {
+                                Span span = spanMap.get(failure.getStreamName());
+                                if (span != null) {
+                                    StringBuilder statusDescription = new StringBuilder();
+                                    failure.visit(new MultiAppendStreamErrorVisitor() {
+                                        @Override
+                                        public void onWrongExpectedRevision(long streamRevision) {
+                                            statusDescription.append(ErrorCase.STREAM_REVISION_CONFLICT);
+                                        }
+
+                                        @Override
+                                        public void onAccessDenied(io.kurrentdb.protocol.streams.v2.ErrorDetails.AccessDenied detail) {
+                                            statusDescription.append(ErrorCase.ACCESS_DENIED);
+                                        }
+
+                                        @Override
+                                        public void onStreamDeleted() {
+                                            statusDescription.append(ErrorCase.STREAM_DELETED);
+                                        }
+
+                                        @Override
+                                        public void onTransactionMaxSizeExceeded(int maxSize) {
+                                            statusDescription.append(ErrorCase.TRANSACTION_MAX_SIZE_EXCEEDED);
+                                        }
+                                    });
+
+                                    span.setStatus(StatusCode.ERROR, statusDescription.toString());
+                                    span.end();
+                                    processedStreams.add(failure.getStreamName());
+                                }
+                            }
+
+                            spanMap.entrySet().stream().filter(entry -> !processedStreams.contains(entry.getKey())).forEach(entry -> {
+                                entry.getValue().setStatus(StatusCode.ERROR);
+                                entry.getValue().end();
+                            });
+                        } else if (result.getSuccesses().isPresent()) {
+                            result.getSuccesses().get().stream().map(success -> spanMap.get(success.getStreamName())).filter(Objects::nonNull).forEach(span -> {
+                                span.setStatus(StatusCode.OK);
+                                span.end();
+                            });
+                        }
+
+                        return result;
+                    }
+                });
     }
 
     static void traceSubscribe(Runnable tracedOperation, String subscriptionId, ManagedChannel channel,

--- a/src/main/java/io/kurrent/dbclient/ClientTelemetry.java
+++ b/src/main/java/io/kurrent/dbclient/ClientTelemetry.java
@@ -129,23 +129,19 @@ class ClientTelemetry {
             Iterator<AppendStreamRequest> requests, KurrentDBClientSettings settings) {
 
         List<AppendStreamRequest> requestsWithTracing = new ArrayList<>();
-        List<Span> spans = new ArrayList<>();
+
+        Span span = createSpan(
+                ClientTelemetryConstants.Operations.MULTI_APPEND,
+                SpanKind.CLIENT,
+                null,
+                ClientTelemetryTags.builder()
+                        .withServerTagsFromGrpcChannel(args.getChannel())
+                        .withServerTagsFromClientSettings(settings)
+                        .withOptionalDatabaseUserTag(settings.getDefaultCredentials())
+                        .build());
 
         while (requests.hasNext()) {
             AppendStreamRequest request = requests.next();
-
-            Span span = createSpan(
-                    ClientTelemetryConstants.Operations.APPEND,
-                    SpanKind.CLIENT,
-                    null,
-                    ClientTelemetryTags.builder()
-                            .withRequiredTag(ClientTelemetryAttributes.KurrentDB.STREAM, request.getStreamName())
-                            .withServerTagsFromGrpcChannel(args.getChannel())
-                            .withServerTagsFromClientSettings(settings)
-                            .withOptionalDatabaseUserTag(settings.getDefaultCredentials())
-                            .build());
-
-            spans.add(span);
 
             List<EventData> eventsWithTracing = new ArrayList<>();
             while (request.getEvents().hasNext())
@@ -163,56 +159,50 @@ class ClientTelemetry {
         return multiAppendOperation.apply(args, requestsWithTracing.iterator())
                 .handle((result, throwable) -> {
                     if (throwable != null) {
-                        for (Span span : spans) {
-                            span.setStatus(StatusCode.ERROR);
-                            span.recordException(throwable);
-                            span.end();
-                        }
+                        span.setStatus(StatusCode.ERROR);
+                        span.recordException(throwable);
+                        span.end();
                         throw new CompletionException(throwable);
                     } else {
                         if (result.getFailures().isPresent()) {
-                            for (Span span : spans) {
-                                for (AppendStreamFailure failure : result.getFailures().get()) {
-                                    failure.visit(new MultiAppendStreamErrorVisitor() {
-                                        @Override
-                                        public void onWrongExpectedRevision(long streamRevision) {
-                                            span.addEvent("exception", Attributes.of(
-                                                    AttributeKey.stringKey("exception.type"), ErrorCase.STREAM_REVISION_CONFLICT.toString(),
-                                                    AttributeKey.longKey("exception.revision"), streamRevision
-                                            ));
-                                        }
+                            for (AppendStreamFailure failure : result.getFailures().get()) {
+                                failure.visit(new MultiAppendStreamErrorVisitor() {
+                                    @Override
+                                    public void onWrongExpectedRevision(long streamRevision) {
+                                        span.addEvent("exception", Attributes.of(
+                                                AttributeKey.stringKey("exception.type"), ErrorCase.STREAM_REVISION_CONFLICT.toString(),
+                                                AttributeKey.longKey("exception.revision"), streamRevision
+                                        ));
+                                    }
 
-                                        @Override
-                                        public void onAccessDenied(io.kurrentdb.protocol.streams.v2.ErrorDetails.AccessDenied detail) {
-                                            span.addEvent("exception", Attributes.of(
-                                                    AttributeKey.stringKey("exception.type"), ErrorCase.ACCESS_DENIED.toString()
-                                            ));
-                                        }
+                                    @Override
+                                    public void onAccessDenied(io.kurrentdb.protocol.streams.v2.ErrorDetails.AccessDenied detail) {
+                                        span.addEvent("exception", Attributes.of(
+                                                AttributeKey.stringKey("exception.type"), ErrorCase.ACCESS_DENIED.toString()
+                                        ));
+                                    }
 
-                                        @Override
-                                        public void onStreamDeleted() {
-                                            span.addEvent("exception", Attributes.of(
-                                                    AttributeKey.stringKey("exception.type"), ErrorCase.STREAM_DELETED.toString()
-                                            ));
-                                        }
+                                    @Override
+                                    public void onStreamDeleted() {
+                                        span.addEvent("exception", Attributes.of(
+                                                AttributeKey.stringKey("exception.type"), ErrorCase.STREAM_DELETED.toString()
+                                        ));
+                                    }
 
-                                        @Override
-                                        public void onTransactionMaxSizeExceeded(int maxSize) {
-                                            span.addEvent("exception", Attributes.of(
-                                                    AttributeKey.stringKey("exception.type"), ErrorCase.TRANSACTION_MAX_SIZE_EXCEEDED.toString(),
-                                                    AttributeKey.longKey("exception.maxSize"), (long) maxSize
-                                            ));
-                                        }
-                                    });
-                                }
-                                span.setStatus(StatusCode.ERROR);
-                                span.end();
+                                    @Override
+                                    public void onTransactionMaxSizeExceeded(int maxSize) {
+                                        span.addEvent("exception", Attributes.of(
+                                                AttributeKey.stringKey("exception.type"), ErrorCase.TRANSACTION_MAX_SIZE_EXCEEDED.toString(),
+                                                AttributeKey.longKey("exception.maxSize"), (long) maxSize
+                                        ));
+                                    }
+                                });
                             }
+                            span.setStatus(StatusCode.ERROR);
+                            span.end();
                         } else if (result.getSuccesses().isPresent()) {
-                            for (Span span : spans) {
-                                span.setStatus(StatusCode.OK);
-                                span.end();
-                            }
+                            span.setStatus(StatusCode.OK);
+                            span.end();
                         }
 
                         return result;

--- a/src/main/java/io/kurrent/dbclient/ClientTelemetry.java
+++ b/src/main/java/io/kurrent/dbclient/ClientTelemetry.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.grpc.ManagedChannel;
-import io.kurrentdb.protocol.streams.v2.AppendStreamFailure.ErrorCase;
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.*;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -14,6 +15,8 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
+
+import static io.kurrentdb.protocol.streams.v2.AppendStreamFailure.*;
 
 class ClientTelemetry {
     private static final ClientTelemetryTags DEFAULT_ATTRIBUTES = new ClientTelemetryTags() {{
@@ -126,7 +129,7 @@ class ClientTelemetry {
             Iterator<AppendStreamRequest> requests, KurrentDBClientSettings settings) {
 
         List<AppendStreamRequest> requestsWithTracing = new ArrayList<>();
-        Map<String, Span> spanMap = new HashMap<>();
+        List<Span> spans = new ArrayList<>();
 
         while (requests.hasNext()) {
             AppendStreamRequest request = requests.next();
@@ -142,7 +145,7 @@ class ClientTelemetry {
                             .withOptionalDatabaseUserTag(settings.getDefaultCredentials())
                             .build());
 
-            spanMap.put(request.getStreamName(), span);
+            spans.add(span);
 
             List<EventData> eventsWithTracing = new ArrayList<>();
             while (request.getEvents().hasNext())
@@ -160,7 +163,7 @@ class ClientTelemetry {
         return multiAppendOperation.apply(args, requestsWithTracing.iterator())
                 .handle((result, throwable) -> {
                     if (throwable != null) {
-                        for (Span span : spanMap.values()) {
+                        for (Span span : spans) {
                             span.setStatus(StatusCode.ERROR);
                             span.recordException(throwable);
                             span.end();
@@ -168,49 +171,48 @@ class ClientTelemetry {
                         throw new CompletionException(throwable);
                     } else {
                         if (result.getFailures().isPresent()) {
-                            Set<String> processedStreams = new HashSet<>();
-
-                            for (AppendStreamFailure failure : result.getFailures().get()) {
-                                Span span = spanMap.get(failure.getStreamName());
-                                if (span != null) {
-                                    StringBuilder statusDescription = new StringBuilder();
+                            for (Span span : spans) {
+                                for (AppendStreamFailure failure : result.getFailures().get()) {
                                     failure.visit(new MultiAppendStreamErrorVisitor() {
                                         @Override
                                         public void onWrongExpectedRevision(long streamRevision) {
-                                            statusDescription.append(ErrorCase.STREAM_REVISION_CONFLICT);
+                                            span.addEvent("exception", Attributes.of(
+                                                    AttributeKey.stringKey("exception.type"), ErrorCase.STREAM_REVISION_CONFLICT.toString(),
+                                                    AttributeKey.longKey("exception.revision"), streamRevision
+                                            ));
                                         }
 
                                         @Override
                                         public void onAccessDenied(io.kurrentdb.protocol.streams.v2.ErrorDetails.AccessDenied detail) {
-                                            statusDescription.append(ErrorCase.ACCESS_DENIED);
+                                            span.addEvent("exception", Attributes.of(
+                                                    AttributeKey.stringKey("exception.type"), ErrorCase.ACCESS_DENIED.toString()
+                                            ));
                                         }
 
                                         @Override
                                         public void onStreamDeleted() {
-                                            statusDescription.append(ErrorCase.STREAM_DELETED);
+                                            span.addEvent("exception", Attributes.of(
+                                                    AttributeKey.stringKey("exception.type"), ErrorCase.STREAM_DELETED.toString()
+                                            ));
                                         }
 
                                         @Override
                                         public void onTransactionMaxSizeExceeded(int maxSize) {
-                                            statusDescription.append(ErrorCase.TRANSACTION_MAX_SIZE_EXCEEDED);
+                                            span.addEvent("exception", Attributes.of(
+                                                    AttributeKey.stringKey("exception.type"), ErrorCase.TRANSACTION_MAX_SIZE_EXCEEDED.toString(),
+                                                    AttributeKey.longKey("exception.maxSize"), (long) maxSize
+                                            ));
                                         }
                                     });
-
-                                    span.setStatus(StatusCode.ERROR, statusDescription.toString());
-                                    span.end();
-                                    processedStreams.add(failure.getStreamName());
                                 }
+                                span.setStatus(StatusCode.ERROR);
+                                span.end();
                             }
-
-                            spanMap.entrySet().stream().filter(entry -> !processedStreams.contains(entry.getKey())).forEach(entry -> {
-                                entry.getValue().setStatus(StatusCode.ERROR);
-                                entry.getValue().end();
-                            });
                         } else if (result.getSuccesses().isPresent()) {
-                            result.getSuccesses().get().stream().map(success -> spanMap.get(success.getStreamName())).filter(Objects::nonNull).forEach(span -> {
+                            for (Span span : spans) {
                                 span.setStatus(StatusCode.OK);
                                 span.end();
-                            });
+                            }
                         }
 
                         return result;

--- a/src/main/java/io/kurrent/dbclient/ClientTelemetryConstants.java
+++ b/src/main/java/io/kurrent/dbclient/ClientTelemetryConstants.java
@@ -10,7 +10,7 @@ public class ClientTelemetryConstants {
 
     public static class Operations {
         public static final String APPEND = "streams.append";
-        public static final String MULTI_STREAM_APPEND = "streams.multi_stream_append";
+        public static final String MULTI_APPEND = "streams.multi-append";
         public static final String SUBSCRIBE = "streams.subscribe";
     }
 }

--- a/src/main/java/io/kurrent/dbclient/ClientTelemetryConstants.java
+++ b/src/main/java/io/kurrent/dbclient/ClientTelemetryConstants.java
@@ -10,6 +10,7 @@ public class ClientTelemetryConstants {
 
     public static class Operations {
         public static final String APPEND = "streams.append";
+        public static final String MULTI_STREAM_APPEND = "streams.multi_stream_append";
         public static final String SUBSCRIBE = "streams.subscribe";
     }
 }

--- a/src/main/java/io/kurrent/dbclient/MultiStreamAppend.java
+++ b/src/main/java/io/kurrent/dbclient/MultiStreamAppend.java
@@ -25,10 +25,14 @@ class MultiStreamAppend {
     }
 
     public CompletableFuture<MultiAppendWriteResult> execute() {
-        return this.client.runWithArgs(this::append);
+        return this.client.runWithArgs(args -> ClientTelemetry.traceMultiStreamAppend(
+                this::append,
+                args,
+                this.requests,
+                this.client.getSettings()));
     }
 
-    private CompletableFuture<MultiAppendWriteResult> append(WorkItemArgs args) {
+    private CompletableFuture<MultiAppendWriteResult> append(WorkItemArgs args, Iterator<AppendStreamRequest> requests) {
         CompletableFuture<MultiAppendWriteResult> result = new CompletableFuture<>();
 
         if (!args.supportFeature(FeatureFlags.MULTI_STREAM_APPEND)) {
@@ -40,8 +44,8 @@ class MultiStreamAppend {
         StreamObserver<io.kurrentdb.protocol.streams.v2.AppendStreamRequest> requestStream = client.multiStreamAppendSession(GrpcUtils.convertSingleResponse(result, this::onResponse));
 
        try {
-           while (this.requests.hasNext()) {
-                AppendStreamRequest request = this.requests.next();
+           while (requests.hasNext()) {
+                AppendStreamRequest request = requests.next();
                 io.kurrentdb.protocol.streams.v2.AppendStreamRequest.Builder builder = io.kurrentdb.protocol.streams.v2.AppendStreamRequest.newBuilder()
                         .setExpectedRevision(request.getExpectedState().toRawLong())
                         .setStream(request.getStreamName());

--- a/src/test/java/io/kurrent/dbclient/TelemetryTests.java
+++ b/src/test/java/io/kurrent/dbclient/TelemetryTests.java
@@ -6,9 +6,12 @@ import io.kurrent.dbclient.telemetry.StreamsTracingInstrumentationTests;
 import io.kurrent.dbclient.telemetry.TracingContextInjectionTests;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +23,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 
 public class TelemetryTests implements StreamsTracingInstrumentationTests, PersistentSubscriptionsTracingInstrumentationTests, TracingContextInjectionTests {
     static private Database database;
@@ -39,10 +44,20 @@ public class TelemetryTests implements StreamsTracingInstrumentationTests, Persi
         GlobalOpenTelemetry.resetForTest();
         spanEndedHooks.add(recordedSpans::add);
 
+        OtlpGrpcSpanExporter otlpExporter = OtlpGrpcSpanExporter.builder()
+                .setEndpoint("http://localhost:4317")
+                .build();
+
+        Resource resource = Resource.getDefault().toBuilder()
+                .put(SERVICE_NAME, "kurrentdb")
+                .build();
+
         OpenTelemetrySdk.builder()
                 .setTracerProvider(SdkTracerProvider
                         .builder()
                         .addSpanProcessor(new SpanProcessorSpy(spanEndedHooks))
+                        .addSpanProcessor(SimpleSpanProcessor.create(otlpExporter))
+                        .setResource(resource)
                         .build())
                 .buildAndRegisterGlobal();
     }

--- a/src/test/java/io/kurrent/dbclient/databases/DockerContainerDatabase.java
+++ b/src/test/java/io/kurrent/dbclient/databases/DockerContainerDatabase.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class DockerContainerDatabase extends GenericContainer<DockerContainerDatabase> implements Database {
-    public static final String DEFAULT_IMAGE = "docker.kurrent.io/eventstore/eventstoredb-ee:lts";
+    public static final String DEFAULT_IMAGE = "docker.cloudsmith.io/eventstore/kurrent-staging/kurrentdb:ci";
 
     public static class Builder {
         String image;

--- a/src/test/java/io/kurrent/dbclient/telemetry/StreamsTracingInstrumentationTests.java
+++ b/src/test/java/io/kurrent/dbclient/telemetry/StreamsTracingInstrumentationTests.java
@@ -3,12 +3,18 @@ package io.kurrent.dbclient.telemetry;
 import io.kurrent.dbclient.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.kurrentdb.protocol.streams.v2.AppendStreamFailure.ErrorCase;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -288,5 +294,114 @@ public interface StreamsTracingInstrumentationTests extends TelemetryAware {
 
         List<ReadableSpan> subscribeSpans = getSpansForOperation(ClientTelemetryConstants.Operations.SUBSCRIBE);
         Assertions.assertTrue(subscribeSpans.isEmpty(), "No spans should be recorded for deleted events");
+    }
+
+    @Test
+    default void testMultiStreamAppendIsInstrumentedWithTracingAsExpected() throws Throwable {
+        KurrentDBClient client = getDefaultClient();
+        String streamName1 = generateName();
+        String streamName2 = generateName();
+
+        EventData event1 = EventData.builderAsJson("TestEvent", mapper.writeValueAsBytes(new Foo()))
+                .eventId(UUID.randomUUID())
+                .build();
+
+        EventData event2 = EventData.builderAsJson("TestEvent", mapper.writeValueAsBytes(new Foo()))
+                .eventId(UUID.randomUUID())
+                .build();
+
+        AppendStreamRequest request1 = new AppendStreamRequest(
+                streamName1,
+                Collections.singletonList(event1).iterator(),
+                StreamState.noStream()
+        );
+
+        AppendStreamRequest request2 = new AppendStreamRequest(
+                streamName2,
+                Collections.singletonList(event2).iterator(),
+                StreamState.noStream()
+        );
+
+        MultiAppendWriteResult result = client.multiStreamAppend(
+                Arrays.asList(request1, request2).iterator()
+        ).get();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.getSuccesses().isPresent());
+
+        List<ReadableSpan> spans = getSpansForOperation(ClientTelemetryConstants.Operations.APPEND);
+        Assertions.assertEquals(2, spans.size());
+
+        ReadableSpan span1 = spans.stream()
+                .filter(span -> streamName1.equals(span.getAttribute(AttributeKey.stringKey(ClientTelemetryAttributes.KurrentDB.STREAM))))
+                .findFirst()
+                .orElse(null);
+
+        ReadableSpan span2 = spans.stream()
+                .filter(span -> streamName2.equals(span.getAttribute(AttributeKey.stringKey(ClientTelemetryAttributes.KurrentDB.STREAM))))
+                .findFirst()
+                .orElse(null);
+
+        Assertions.assertNotNull(span1);
+        Assertions.assertNotNull(span2);
+
+        assertAppendSpanHasExpectedAttributes(span1, streamName1);
+        assertAppendSpanHasExpectedAttributes(span2, streamName2);
+    }
+
+    @Test
+    default void testMultiStreamAppendIsInstrumentedWithFailures() throws Throwable {
+        KurrentDBClient client = getDefaultClient();
+        String streamName1 = generateName();
+        String streamName2 = generateName();
+
+        EventData event1 = EventData.builderAsJson("TestEvent", mapper.writeValueAsBytes(new Foo()))
+                .eventId(UUID.randomUUID())
+                .build();
+
+        EventData event2 = EventData.builderAsJson("TestEvent", mapper.writeValueAsBytes(new Foo()))
+                .eventId(UUID.randomUUID())
+                .build();
+
+        AppendStreamRequest request1 = new AppendStreamRequest(
+                streamName1,
+                Collections.singletonList(event1).iterator(),
+                StreamState.noStream()
+        );
+
+        AppendStreamRequest request2 = new AppendStreamRequest(
+                streamName2,
+                Collections.singletonList(event2).iterator(),
+                StreamState.streamExists()
+        );
+
+        MultiAppendWriteResult result = client.multiStreamAppend(
+                Arrays.asList(request1, request2).iterator()
+        ).get();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.getSuccesses().isPresent());
+
+        List<ReadableSpan> spans = getSpansForOperation(ClientTelemetryConstants.Operations.APPEND);
+        Assertions.assertEquals(2, spans.size());
+
+        ReadableSpan span1 = spans.stream()
+                .filter(span -> streamName1.equals(span.getAttribute(AttributeKey.stringKey(ClientTelemetryAttributes.KurrentDB.STREAM))))
+                .findFirst()
+                .orElse(null);
+
+        ReadableSpan span2 = spans.stream()
+                .filter(span -> streamName2.equals(span.getAttribute(AttributeKey.stringKey(ClientTelemetryAttributes.KurrentDB.STREAM))))
+                .findFirst()
+                .orElse(null);
+
+        Assertions.assertNotNull(span1);
+        Assertions.assertNotNull(span2);
+
+        Assertions.assertEquals(StatusCode.ERROR, span1.toSpanData().getStatus().getStatusCode());
+        Assertions.assertEquals("", span1.toSpanData().getStatus().getDescription());
+
+        Assertions.assertEquals(StatusCode.ERROR, span2.toSpanData().getStatus().getStatusCode());
+        Assertions.assertEquals(ErrorCase.STREAM_REVISION_CONFLICT.toString(), span2.toSpanData().getStatus().getDescription());
     }
 }

--- a/src/test/java/io/kurrent/dbclient/telemetry/StreamsTracingInstrumentationTests.java
+++ b/src/test/java/io/kurrent/dbclient/telemetry/StreamsTracingInstrumentationTests.java
@@ -335,24 +335,14 @@ public interface StreamsTracingInstrumentationTests extends TelemetryAware {
         Assertions.assertNotNull(result);
         Assertions.assertTrue(result.getSuccesses().isPresent());
 
-        List<ReadableSpan> spans = getSpansForOperation(ClientTelemetryConstants.Operations.APPEND);
-        Assertions.assertEquals(2, spans.size());
+        List<ReadableSpan> spans = getSpansForOperation(ClientTelemetryConstants.Operations.MULTI_APPEND);
+        Assertions.assertEquals(1, spans.size());
 
-        ReadableSpan span1 = spans.stream()
-                .filter(span -> streamName1.equals(span.getAttribute(AttributeKey.stringKey(ClientTelemetryAttributes.KurrentDB.STREAM))))
-                .findFirst()
-                .orElse(null);
-
-        ReadableSpan span2 = spans.stream()
-                .filter(span -> streamName2.equals(span.getAttribute(AttributeKey.stringKey(ClientTelemetryAttributes.KurrentDB.STREAM))))
-                .findFirst()
-                .orElse(null);
-
-        Assertions.assertNotNull(span1);
-        Assertions.assertNotNull(span2);
-
-        assertAppendSpanHasExpectedAttributes(span1, streamName1);
-        assertAppendSpanHasExpectedAttributes(span2, streamName2);
+        assertSpanAttributeEquals(spans.get(0), ClientTelemetryAttributes.Database.SYSTEM, ClientTelemetryConstants.INSTRUMENTATION_NAME);
+        assertSpanAttributeEquals(spans.get(0), ClientTelemetryAttributes.Database.OPERATION, ClientTelemetryConstants.Operations.MULTI_APPEND);
+        assertSpanAttributeEquals(spans.get(0), ClientTelemetryAttributes.Database.USER, "admin");
+        Assertions.assertEquals(StatusCode.OK, spans.get(0).toSpanData().getStatus().getStatusCode());
+        Assertions.assertEquals(SpanKind.CLIENT, spans.get(0).getKind());
     }
 
     @Test
@@ -397,47 +387,26 @@ public interface StreamsTracingInstrumentationTests extends TelemetryAware {
         Assertions.assertFalse(result.getSuccesses().isPresent());
         Assertions.assertTrue(result.getFailures().isPresent());
 
-        List<ReadableSpan> spans = getSpansForOperation(ClientTelemetryConstants.Operations.APPEND);
-        Assertions.assertEquals(2, spans.size());
+        List<ReadableSpan> spans = getSpansForOperation(ClientTelemetryConstants.Operations.MULTI_APPEND);
+        Assertions.assertEquals(1, spans.size());
 
-        ReadableSpan span1 = spans.stream()
-                .filter(span -> streamName1.equals(span.getAttribute(AttributeKey.stringKey(ClientTelemetryAttributes.KurrentDB.STREAM))))
-                .findFirst()
-                .orElse(null);
+        ReadableSpan span = spans.get(0);
 
-        ReadableSpan span2 = spans.stream()
-                .filter(span -> streamName2.equals(span.getAttribute(AttributeKey.stringKey(ClientTelemetryAttributes.KurrentDB.STREAM))))
-                .findFirst()
-                .orElse(null);
+        Assertions.assertEquals(StatusCode.ERROR, span.toSpanData().getStatus().getStatusCode());
+        Assertions.assertEquals("", span.toSpanData().getStatus().getDescription());
 
-        Assertions.assertNotNull(span1);
-        Assertions.assertNotNull(span2);
+        List<io.opentelemetry.sdk.trace.data.EventData> events = span.toSpanData().getEvents();
 
-        Assertions.assertEquals(StatusCode.ERROR, span1.toSpanData().getStatus().getStatusCode());
-        Assertions.assertEquals("", span1.toSpanData().getStatus().getDescription());
-        Assertions.assertEquals(StatusCode.ERROR, span2.toSpanData().getStatus().getStatusCode());
-        Assertions.assertEquals("", span2.toSpanData().getStatus().getDescription());
+        Assertions.assertEquals(1, events.size());
 
-        List<io.opentelemetry.sdk.trace.data.EventData> events1 = span1.toSpanData().getEvents();
-        List<io.opentelemetry.sdk.trace.data.EventData> events2 = span2.toSpanData().getEvents();
+        io.opentelemetry.sdk.trace.data.EventData failureEvent = events.get(0);
 
-        Assertions.assertEquals(1, events1.size());
-        Assertions.assertEquals(1, events2.size());
-
-        io.opentelemetry.sdk.trace.data.EventData failureEvent1 = events1.get(0);
-        io.opentelemetry.sdk.trace.data.EventData failureEvent2 = events2.get(0);
-
-        Assertions.assertEquals("exception", failureEvent1.getName());
-        Assertions.assertEquals("exception", failureEvent2.getName());
+        Assertions.assertEquals("exception", failureEvent.getName());
 
         Assertions.assertEquals(ErrorCase.STREAM_REVISION_CONFLICT.toString(),
-                failureEvent1.getAttributes().get(AttributeKey.stringKey("exception.type")));
-        Assertions.assertEquals(ErrorCase.STREAM_REVISION_CONFLICT.toString(),
-                failureEvent2.getAttributes().get(AttributeKey.stringKey("exception.type")));
+                failureEvent.getAttributes().get(AttributeKey.stringKey("exception.type")));
 
-        Assertions.assertNotNull(failureEvent1.getAttributes().get(AttributeKey.longKey("exception.revision")));
-        Assertions.assertNotNull(failureEvent2.getAttributes().get(AttributeKey.longKey("exception.revision")));
-        Assertions.assertEquals(-1L, failureEvent1.getAttributes().get(AttributeKey.longKey("exception.revision")));
-        Assertions.assertEquals(-1L, failureEvent2.getAttributes().get(AttributeKey.longKey("exception.revision")));
+        Assertions.assertNotNull(failureEvent.getAttributes().get(AttributeKey.longKey("exception.revision")));
+        Assertions.assertEquals(-1L, failureEvent.getAttributes().get(AttributeKey.longKey("exception.revision")));
     }
 }

--- a/src/test/java/io/kurrent/dbclient/telemetry/StreamsTracingInstrumentationTests.java
+++ b/src/test/java/io/kurrent/dbclient/telemetry/StreamsTracingInstrumentationTests.java
@@ -10,13 +10,11 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -299,6 +297,14 @@ public interface StreamsTracingInstrumentationTests extends TelemetryAware {
     @Test
     default void testMultiStreamAppendIsInstrumentedWithTracingAsExpected() throws Throwable {
         KurrentDBClient client = getDefaultClient();
+
+        Optional<ServerVersion> version = client.getServerVersion().get();
+
+        Assumptions.assumeTrue(
+                version.isPresent() && version.get().isGreaterOrEqualThan(25, 0),
+                "Multi-stream append is not supported server versions below 25.0.0"
+        );
+
         String streamName1 = generateName();
         String streamName2 = generateName();
 
@@ -352,6 +358,14 @@ public interface StreamsTracingInstrumentationTests extends TelemetryAware {
     @Test
     default void testMultiStreamAppendIsInstrumentedWithFailures() throws Throwable {
         KurrentDBClient client = getDefaultClient();
+
+        Optional<ServerVersion> version = client.getServerVersion().get();
+
+        Assumptions.assumeTrue(
+                version.isPresent() && version.get().isGreaterOrEqualThan(25, 0),
+                "Multi-stream append is not supported server versions below 25.0.0"
+        );
+
         String streamName1 = generateName();
         String streamName2 = generateName();
 

--- a/src/test/java/io/kurrent/dbclient/telemetry/StreamsTracingInstrumentationTests.java
+++ b/src/test/java/io/kurrent/dbclient/telemetry/StreamsTracingInstrumentationTests.java
@@ -395,6 +395,7 @@ public interface StreamsTracingInstrumentationTests extends TelemetryAware {
 
         Assertions.assertNotNull(result);
         Assertions.assertFalse(result.getSuccesses().isPresent());
+        Assertions.assertTrue(result.getFailures().isPresent());
 
         List<ReadableSpan> spans = getSpansForOperation(ClientTelemetryConstants.Operations.APPEND);
         Assertions.assertEquals(2, spans.size());
@@ -414,8 +415,29 @@ public interface StreamsTracingInstrumentationTests extends TelemetryAware {
 
         Assertions.assertEquals(StatusCode.ERROR, span1.toSpanData().getStatus().getStatusCode());
         Assertions.assertEquals("", span1.toSpanData().getStatus().getDescription());
-
         Assertions.assertEquals(StatusCode.ERROR, span2.toSpanData().getStatus().getStatusCode());
-        Assertions.assertEquals(ErrorCase.STREAM_REVISION_CONFLICT.toString(), span2.toSpanData().getStatus().getDescription());
+        Assertions.assertEquals("", span2.toSpanData().getStatus().getDescription());
+
+        List<io.opentelemetry.sdk.trace.data.EventData> events1 = span1.toSpanData().getEvents();
+        List<io.opentelemetry.sdk.trace.data.EventData> events2 = span2.toSpanData().getEvents();
+
+        Assertions.assertEquals(1, events1.size());
+        Assertions.assertEquals(1, events2.size());
+
+        io.opentelemetry.sdk.trace.data.EventData failureEvent1 = events1.get(0);
+        io.opentelemetry.sdk.trace.data.EventData failureEvent2 = events2.get(0);
+
+        Assertions.assertEquals("exception", failureEvent1.getName());
+        Assertions.assertEquals("exception", failureEvent2.getName());
+
+        Assertions.assertEquals(ErrorCase.STREAM_REVISION_CONFLICT.toString(),
+                failureEvent1.getAttributes().get(AttributeKey.stringKey("exception.type")));
+        Assertions.assertEquals(ErrorCase.STREAM_REVISION_CONFLICT.toString(),
+                failureEvent2.getAttributes().get(AttributeKey.stringKey("exception.type")));
+
+        Assertions.assertNotNull(failureEvent1.getAttributes().get(AttributeKey.longKey("exception.revision")));
+        Assertions.assertNotNull(failureEvent2.getAttributes().get(AttributeKey.longKey("exception.revision")));
+        Assertions.assertEquals(-1L, failureEvent1.getAttributes().get(AttributeKey.longKey("exception.revision")));
+        Assertions.assertEquals(-1L, failureEvent2.getAttributes().get(AttributeKey.longKey("exception.revision")));
     }
 }


### PR DESCRIPTION
Create a single span for multi stream append operation with name `streams.multi-append`. Failures are added as events.