### PR TITLE
[DEV-1038] fix: add missing no stream case to expected revision error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <a href="https://kurrent.io">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="KurrentLogo-White.png">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <a href="https://kurrent.io">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="KurrentLogo-White.png">

--- a/src/main/java/io/kurrent/dbclient/AppendToStream.java
+++ b/src/main/java/io/kurrent/dbclient/AppendToStream.java
@@ -70,6 +70,8 @@ class AppendToStream {
                     expectedRevision = StreamState.any();
                 } else if (wev.getExpectedRevisionOptionCase() == StreamsOuterClass.AppendResp.WrongExpectedVersion.ExpectedRevisionOptionCase.EXPECTED_STREAM_EXISTS) {
                     expectedRevision = StreamState.streamExists();
+                } else if (wev.getExpectedRevisionOptionCase() == StreamsOuterClass.AppendResp.WrongExpectedVersion.ExpectedRevisionOptionCase.EXPECTED_NO_STREAM) {
+                    expectedRevision = StreamState.noStream();
                 } else {
                     expectedRevision = StreamState.streamRevision(wev.getExpectedRevision());
                 }

--- a/src/main/java/io/kurrent/dbclient/AppendToStream.java
+++ b/src/main/java/io/kurrent/dbclient/AppendToStream.java
@@ -7,6 +7,7 @@ import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.stub.StreamObserver;
 
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;

--- a/src/test/java/io/kurrent/dbclient/streams/AppendTests.java
+++ b/src/test/java/io/kurrent/dbclient/streams/AppendTests.java
@@ -12,36 +12,27 @@ public interface AppendTests extends ConnectionAware {
     default void testAppendSingleEventNoStream() throws Throwable {
         KurrentDBClient client = getDatabase().defaultClient();
         String streamName = generateName();
-        String eventType = "TestEvent";
         UUID eventId = UUID.randomUUID();
         Foo foo = new Foo();
         byte[] fooBytes = mapper.writeValueAsBytes(foo);
 
-        EventData event = EventData.builderAsJson(eventType, fooBytes)
+        EventData event = EventData.builderAsJson("TestEvent", fooBytes)
                 .metadataAsBytes(fooBytes)
                 .eventId(eventId)
                 .build();
 
         WriteResult appendResult = client.appendToStream(
-                streamName,
-                AppendToStreamOptions.get().streamState(StreamState.noStream()),
-                event
-        ).get();
+                streamName, AppendToStreamOptions.get().streamState(StreamState.noStream()), event).get();
 
         Assertions.assertEquals(StreamState.streamRevision(0), appendResult.getNextExpectedRevision());
 
-        ReadResult result = client.readStream(
-                streamName,
-                ReadStreamOptions.get().fromEnd().backwards().maxCount(1)
-        ).get();
-
-        Assertions.assertEquals(1, result.getEvents().size());
+        ReadResult result = client.readStream(streamName, ReadStreamOptions.get().fromEnd().backwards().maxCount(1)).get();
         RecordedEvent first = result.getEvents().get(0).getEvent();
         ObjectNode userMetadata = mapper.readValue(first.getUserMetadata(), ObjectNode.class);
 
         Assertions.assertAll(
                 () -> Assertions.assertEquals(streamName, first.getStreamId()),
-                () -> Assertions.assertEquals(eventType, first.getEventType()),
+                () -> Assertions.assertEquals("TestEvent", first.getEventType()),
                 () -> Assertions.assertEquals(eventId.toString(), first.getEventId().toString()),
                 () -> Assertions.assertEquals(foo, mapper.readValue(first.getEventData(), Foo.class)),
                 () -> Assertions.assertEquals(foo, mapper.readValue(first.getUserMetadata(), Foo.class)),
@@ -49,4 +40,69 @@ public interface AppendTests extends ConnectionAware {
                 () -> Assertions.assertFalse(userMetadata.has(ClientTelemetryConstants.Metadata.SPAN_ID))
         );
     }
+
+    @Test
+    default void testAppendMultipleEventsAtOnce() throws Throwable {
+        KurrentDBClient client = getDatabase().defaultClient();
+        String streamName = generateName();
+        int eventCount = 5;
+
+        WriteResult result = client.appendToStream(streamName,
+                AppendToStreamOptions.get().streamState(StreamState.noStream()),
+                generateEvents(eventCount, "TestEvent").iterator()).get();
+
+        Assertions.assertEquals(StreamState.streamRevision(eventCount - 1), result.getNextExpectedRevision());
+        Assertions.assertEquals(eventCount, client.readStream(streamName, ReadStreamOptions.get()).get().getEvents().size());
+    }
+
+    @Test
+    default void testStreamStateOptimisticConcurrency() throws Throwable {
+        KurrentDBClient client = getDatabase().defaultClient();
+
+        String anyStream = generateName();
+        appendEvent(client, anyStream, StreamState.any());
+        appendEvent(client, anyStream, StreamState.any());
+        Assertions.assertEquals(2, client.readStream(anyStream, ReadStreamOptions.get()).get().getEvents().size());
+
+        String existsStream = generateName();
+        assertWrongExpectedVersion(client, existsStream, StreamState.streamExists(), StreamState.streamExists(), StreamState.noStream());
+        appendEvent(client, existsStream, StreamState.noStream());
+        appendEvent(client, existsStream, StreamState.streamExists());
+
+        String noStream = generateName();
+        appendEvent(client, noStream, StreamState.noStream());
+        assertWrongExpectedVersion(client, noStream, StreamState.noStream(), StreamState.noStream(), StreamState.streamRevision(0));
+
+        String revStream = generateName();
+        appendEvent(client, revStream, StreamState.noStream());
+        appendEvent(client, revStream, StreamState.streamRevision(0));
+        assertWrongExpectedVersion(client, revStream, StreamState.streamRevision(99), StreamState.streamRevision(99), StreamState.streamRevision(1));
+    }
+
+    default EventData createTestEvent() throws Exception {
+        return EventData.builderAsJson("TestEvent", mapper.writeValueAsBytes(new Foo()))
+                .eventId(UUID.randomUUID())
+                .build();
+    }
+
+    default void appendEvent(KurrentDBClient client, String streamName, StreamState state) throws Exception {
+        client.appendToStream(streamName, AppendToStreamOptions.get().streamState(state), createTestEvent()).get();
+    }
+
+    default void assertWrongExpectedVersion(KurrentDBClient client, String streamName, StreamState state, StreamState expectedState, StreamState actualState) {
+        WrongExpectedVersionException ex = Assertions.assertThrows(WrongExpectedVersionException.class, () -> {
+            try {
+                appendEvent(client, streamName, state);
+            } catch (java.util.concurrent.ExecutionException e) {
+                if (e.getCause() != null) {
+                    throw e.getCause();
+                }
+                throw e;
+            }
+        });
+        Assertions.assertEquals(streamName, ex.getStreamName());
+        Assertions.assertEquals(expectedState, ex.getExpectedState());
+        Assertions.assertEquals(actualState, ex.getActualState());
+    }
+
 }


### PR DESCRIPTION
### **PR Type**
fixes: https://github.com/kurrent-io/KurrentDB-Client-Java/issues/362

Bug fix, Tests

___

### **Description**
- Add missing `EXPECTED_NO_STREAM` case to error handling in `AppendToStream`

- Previously fell through to else branch, incorrectly returning streamRevision

- Expand test coverage with multiple new test cases for stream state scenarios

- Refactor existing test for improved readability and code organization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AppendToStream Error Response"] -->|EXPECTED_ANY| B["StreamState.any()"]
  A -->|EXPECTED_STREAM_EXISTS| C["StreamState.streamExists()"]
  A -->|EXPECTED_NO_STREAM| D["StreamState.noStream()"]
  A -->|Other| E["StreamState.streamRevision()"]
  D --> F["Correct State Returned"]
  E --> G["Tests Validate All Cases"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AppendToStream.java</strong><dd><code>Handle EXPECTED_NO_STREAM in error response parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/kurrent/dbclient/AppendToStream.java

<ul><li>Add handling for <code>EXPECTED_NO_STREAM</code> case in <code>WrongExpectedVersion</code> error <br>response parsing<br> <li> Return <code>StreamState.noStream()</code> instead of falling through to default <br>streamRevision case<br> <li> Add blank line for code formatting consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB-Client-Java/pull/363/files#diff-8f1450d1f78b0e4574dad85cd414c69f8966e38d52403345b4d02cca218f3624">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AppendTests.java</strong><dd><code>Expand append tests with comprehensive stream state coverage</code></dd></summary>
<hr>

src/test/java/io/kurrent/dbclient/streams/AppendTests.java

<ul><li>Refactor <code>testAppendSingleEventNoStream()</code> for improved readability and <br>removed intermediate variable<br> <li> Add <code>testAppendMultipleEventsAtOnce()</code> to test appending multiple events <br>in single operation<br> <li> Add <code>testStreamStateOptimisticConcurrency()</code> to validate all stream <br>state scenarios and error cases<br> <li> Add helper methods: <code>createTestEvent()</code>, <code>appendEvent()</code>, and <br><code>assertWrongExpectedVersion()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB-Client-Java/pull/363/files#diff-38e5e5d28ded27dd62a3d131d20fdacaaff0a663282b33a809abb41ad29c30e2">+66/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Minor formatting adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Add blank line at beginning of file


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB-Client-Java/pull/363/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

