### PR TITLE
chore: update docker image to kurrentplatform/kurrentdb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - volumes-provisioner
 
   esdb-node1: &template
-    image: ${KURRENTDB_DOCKER_REGISTRY:-docker.kurrent.io/eventstore}/${KURRENTDB_DOCKER_IMAGE:-eventstoredb-ee}:${KURRENTDB_DOCKER_TAG:-lts}
+    image: ${KURRENTDB_DOCKER_REGISTRY:-kurrentplatform}/${KURRENTDB_DOCKER_IMAGE:-kurrentdb}:${KURRENTDB_DOCKER_TAG:-lts}
     env_file:
       - vars.env
     environment:


### PR DESCRIPTION
## Summary
- Updates the docker-compose image reference from `docker.kurrent.io/eventstore/eventstoredb-ee` to `kurrentplatform/kurrentdb` defaults.

Closes [DEV-1428](https://linear.app/kurrent/issue/DEV-1428/replace-image-in-compose-file)