### PR TITLE
feat: add engineVersion option to projection create

### DIFF
--- a/src/main/java/io/kurrent/dbclient/CreateProjection.java
+++ b/src/main/java/io/kurrent/dbclient/CreateProjection.java
@@ -12,6 +12,7 @@ class CreateProjection {
     private final String query;
     private final boolean trackEmittedStreams;
     private final boolean emitEnabled;
+    private final int engineVersion;
     private final CreateProjectionOptions options;
 
     public CreateProjection(final GrpcClient client, final String projectionName, final String query,
@@ -22,6 +23,7 @@ class CreateProjection {
         this.query = query;
         this.trackEmittedStreams = options.isTrackingEmittedStreams();
         this.emitEnabled = options.isEmitEnabled();
+        this.engineVersion = options.getEngineVersion();
         this.options = options;
     }
 
@@ -36,6 +38,7 @@ class CreateProjection {
             Projectionmanagement.CreateReq.Options.Builder optionsBuilder =
                 Projectionmanagement.CreateReq.Options.newBuilder()
                     .setQuery(query)
+                    .setEngineVersion(engineVersion)
                     .setContinuous(continuousBuilder);
 
             Projectionmanagement.CreateReq request = Projectionmanagement.CreateReq.newBuilder()

--- a/src/main/java/io/kurrent/dbclient/CreateProjectionOptions.java
+++ b/src/main/java/io/kurrent/dbclient/CreateProjectionOptions.java
@@ -6,6 +6,7 @@ package io.kurrent.dbclient;
 public class CreateProjectionOptions extends OptionsBase<CreateProjectionOptions> {
     private boolean trackEmittedStreams;
     private boolean emitEnabled;
+    private int engineVersion;
 
     private CreateProjectionOptions() {
         this.trackEmittedStreams = false;
@@ -26,6 +27,10 @@ public class CreateProjectionOptions extends OptionsBase<CreateProjectionOptions
         return emitEnabled;
     }
 
+    int getEngineVersion() {
+        return engineVersion;
+    }
+
     /**
      * If true, the projection tracks all streams it creates.
      */
@@ -39,6 +44,19 @@ public class CreateProjectionOptions extends OptionsBase<CreateProjectionOptions
      */
     public CreateProjectionOptions emitEnabled(boolean value) {
         this.emitEnabled = value;
+        return this;
+    }
+
+    /**
+     * Selects the projection engine version. {@code 0} (default) or {@code 1} selects V1;
+     * {@code 2} selects the V2 engine, which provides partition-based parallel processing.
+     * <p>
+     * The engine version is pinned at create time and cannot be changed via update.
+     * V2 has limitations versus V1 — notably, {@code trackEmittedStreams} is rejected,
+     * result streams are not emitted, and bi-state projections are not supported.
+     */
+    public CreateProjectionOptions engineVersion(int value) {
+        this.engineVersion = value;
         return this;
     }
 }

--- a/src/main/java/io/kurrent/dbclient/CreateProjectionOptions.java
+++ b/src/main/java/io/kurrent/dbclient/CreateProjectionOptions.java
@@ -52,7 +52,7 @@ public class CreateProjectionOptions extends OptionsBase<CreateProjectionOptions
      * {@code 2} selects the V2 engine, which provides partition-based parallel processing.
      * <p>
      * The engine version is pinned at create time and cannot be changed via update.
-     * V2 has limitations versus V1 — notably, {@code trackEmittedStreams} is rejected,
+     * V2 has limitations versus V1: {@code trackEmittedStreams} is rejected,
      * result streams are not emitted, and bi-state projections are not supported.
      */
     public CreateProjectionOptions engineVersion(int value) {

--- a/src/main/proto/kurrentdb/protocol/v1/projectionmanagement.proto
+++ b/src/main/proto/kurrentdb/protocol/v1/projectionmanagement.proto
@@ -28,6 +28,7 @@ message CreateReq {
 			Continuous continuous = 3;
 		}
 		string query = 4;
+		int32 engine_version = 5; // 0 or 1 = v1 (default), 2 = v2
 
 		message Transient {
 			string name = 1;


### PR DESCRIPTION
## Summary
- Adds `engineVersion(int)` to `CreateProjectionOptions`, exposing the V2 projection engine introduced in KurrentDB
- Adds the `engine_version` field (5) to `CreateReq.Options` in the client proto so the value is sent to the server
- Wires the option through `CreateProjection` so it lands on the gRPC `CreateReq.Options`

V2 selection: `engineVersion(2)` selects V2. `0` (default) or `1` selects V1. The engine version is pinned at create time and cannot be changed via `update`.

V2 has limitations vs V1 (documented on the option's javadoc):
- Result streams are not emitted (no `outputState()` live updates — poll state instead)
- Bi-state projections (`$initShared`) are not supported
- `trackEmittedStreams=true` is rejected by the server

Closes [DEV-1657](https://linear.app/kurrent/issue/DEV-1657/java-or-support-projection-v2-engine).

## Test plan
- [ ] Build with a supported JDK (JDK 25 + Gradle 8.13 fail to evaluate the project locally — unrelated to this change)
- [ ] Confirm protoc generates `setEngineVersion(int)` on `CreateReq.Options.Builder`
- [ ] Manual: create a projection against a KurrentDB build with the V2 engine, with `engineVersion(2)`, verify it runs as V2
- [ ] Manual: create with default options, verify it still runs as V1