### PR TITLE
fix: validate projection engineVersion and V2 trackEmittedStreams combo

### DIFF
--- a/src/main/java/io/kurrent/dbclient/CreateProjection.java
+++ b/src/main/java/io/kurrent/dbclient/CreateProjection.java
@@ -30,10 +30,10 @@ class CreateProjection {
     @SuppressWarnings("unchecked")
     public CompletableFuture execute() {
         if (engineVersion == 2 && trackEmittedStreams) {
-            CompletableFuture<Projectionmanagement.CreateResp> failed = new CompletableFuture<>();
-            failed.completeExceptionally(new IllegalArgumentException(
+            CompletableFuture<Projectionmanagement.CreateResp> result = new CompletableFuture<>();
+            result.completeExceptionally(new IllegalArgumentException(
                     "trackEmittedStreams is not supported when engineVersion is 2 (V2)"));
-            return failed;
+            return result;
         }
 
         return this.client.run(channel -> {

--- a/src/main/java/io/kurrent/dbclient/CreateProjection.java
+++ b/src/main/java/io/kurrent/dbclient/CreateProjection.java
@@ -30,8 +30,10 @@ class CreateProjection {
     @SuppressWarnings("unchecked")
     public CompletableFuture execute() {
         if (engineVersion == 2 && trackEmittedStreams) {
-            throw new IllegalArgumentException(
-                    "trackEmittedStreams is not supported when engineVersion is 2 (V2)");
+            CompletableFuture<Projectionmanagement.CreateResp> failed = new CompletableFuture<>();
+            failed.completeExceptionally(new IllegalArgumentException(
+                    "trackEmittedStreams is not supported when engineVersion is 2 (V2)"));
+            return failed;
         }
 
         return this.client.run(channel -> {

--- a/src/main/java/io/kurrent/dbclient/CreateProjection.java
+++ b/src/main/java/io/kurrent/dbclient/CreateProjection.java
@@ -29,6 +29,11 @@ class CreateProjection {
 
     @SuppressWarnings("unchecked")
     public CompletableFuture execute() {
+        if (engineVersion == 2 && trackEmittedStreams) {
+            throw new IllegalArgumentException(
+                    "trackEmittedStreams is not supported when engineVersion is 2 (V2)");
+        }
+
         return this.client.run(channel -> {
             Projectionmanagement.CreateReq.Options.Continuous.Builder continuousBuilder =
                     Projectionmanagement.CreateReq.Options.Continuous.newBuilder()

--- a/src/main/java/io/kurrent/dbclient/CreateProjectionOptions.java
+++ b/src/main/java/io/kurrent/dbclient/CreateProjectionOptions.java
@@ -54,8 +54,14 @@ public class CreateProjectionOptions extends OptionsBase<CreateProjectionOptions
      * The engine version is pinned at create time and cannot be changed via update.
      * V2 has limitations versus V1: {@code trackEmittedStreams} is rejected,
      * result streams are not emitted, and bi-state projections are not supported.
+     *
+     * @throws IllegalArgumentException if {@code value} is not {@code 0}, {@code 1}, or {@code 2}.
      */
     public CreateProjectionOptions engineVersion(int value) {
+        if (value < 0 || value > 2) {
+            throw new IllegalArgumentException(
+                    "engineVersion must be 0, 1, or 2 (got " + value + ")");
+        }
         this.engineVersion = value;
         return this;
     }


### PR DESCRIPTION
Follow-up to #389.

## Summary
- Reject `engineVersion` values outside `0`/`1`/`2` in `CreateProjectionOptions.engineVersion`.
- Reject `engineVersion == 2 && trackEmittedStreams` in `CreateProjection.execute()` before building the request.

Callers now get an `IllegalArgumentException` locally instead of a server-side error for documented-invalid inputs.
