### PR TITLE
[DEV-1751] Add package imports to Java getting-started and appending-events examples

### DIFF
--- a/docs/api/appending-events.md
+++ b/docs/api/appending-events.md
@@ -14,7 +14,13 @@ Check the [Getting Started](getting-started.md) guide to learn how to configure 
 
 The simplest way to append an event to KurrentDB is to create an `EventData` object and call `appendToStream` method.
 
-```java {32-43}
+```java {38-49}
+import io.kurrent.dbclient.AppendToStreamOptions;
+import io.kurrent.dbclient.EventData;
+import io.kurrent.dbclient.StreamState;
+
+import java.util.UUID;
+
 class OrderPlaced {
     private String orderId;
     private String customerId;

--- a/docs/api/getting-started.md
+++ b/docs/api/getting-started.md
@@ -102,6 +102,10 @@ When connecting to an insecure instance, specify `tls=false` parameter. For exam
 First, create a client and get it connected to the database.
 
 ```java
+import io.kurrent.dbclient.KurrentDBClient;
+import io.kurrent.dbclient.KurrentDBClientSettings;
+import io.kurrent.dbclient.KurrentDBConnectionString;
+
 KurrentDBClientSettings settings = KurrentDBConnectionString.parseOrThrow("kurrentdb://localhost:2113?tls=false");
 KurrentDBClient client = KurrentDBClient.create(settings);
 ```
@@ -115,6 +119,9 @@ You can write anything to KurrentDB as events. The client needs a byte array as 
 The code snippet below creates an event object instance, serializes it, and adds it as a payload to the `EventData` structure, which the client can then write to the database.
 
 ```java
+import io.kurrent.dbclient.EventData;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
 public class OrderPlaced {
     private String orderId;
     private String customerId;


### PR DESCRIPTION
## What

Adds the `import` statements to the Java doc examples on first use of each class:

- **`getting-started.md`** — `io.kurrent.dbclient.{KurrentDBClient, KurrentDBClientSettings, KurrentDBConnectionString}` on the "Creating a client" snippet, and `io.kurrent.dbclient.EventData` + `com.fasterxml.jackson.databind.json.JsonMapper` on the "Creating an event" snippet.
- **`appending-events.md`** — `io.kurrent.dbclient.{AppendToStreamOptions, EventData, StreamState}` and `java.util.UUID` on the first "Append your first event" example. The code-fence highlight range is shifted (`{32-43}` to `{38-49}`) to keep pointing at the append logic.

## Why

The connection and append snippets used `KurrentDBClient`, `EventData`, `AppendToStreamOptions`, etc. without showing where they come from. The build coordinate is `io.kurrent:kurrentdb-client`, but the package is `io.kurrent.dbclient`, so a reader (or a tool generating code from these docs) who reconstructs the import from the artifact name lands on the wrong package (`io.kurrent.client`) and the snippet won't compile.

`AppendToStreamOptions`, `StreamState`, and `UUID` appear only on the appending page, so their imports have to live there.

## Convention preserved

Imports are added only on **first use** of each class. Later snippets on the same page (e.g. the idempotency example in `appending-events.md`) are left unchanged, so the docs aren't cluttered with repeated imports.