### PR TITLE
Fix catch-up subscription onCancelled on leader change

### DIFF
--- a/src/main/java/io/kurrent/dbclient/AbstractRegularSubscription.java
+++ b/src/main/java/io/kurrent/dbclient/AbstractRegularSubscription.java
@@ -40,7 +40,7 @@ abstract class AbstractRegularSubscription {
     protected abstract StreamsOuterClass.ReadReq.Options.Builder createOptions();
 
     public CompletableFuture<Subscription> execute() {
-        return this.client.run(channel -> {
+        return this.client.runWithArgs(args -> {
             CompletableFuture<Subscription> future = new CompletableFuture<>();
 
             StreamsOuterClass.ReadReq readReq = StreamsOuterClass.ReadReq.newBuilder()
@@ -48,12 +48,13 @@ abstract class AbstractRegularSubscription {
                     .build();
 
             StreamsGrpc.StreamsStub streamsClient = GrpcUtils.configureStub(
-                    StreamsGrpc.newStub(channel),
+                    StreamsGrpc.newStub(args.getChannel()),
                     this.client.getSettings(),
                     this.options
             );
 
-            ReadResponseObserver observer = createObserver(channel, future);
+            ReadResponseObserver observer = createObserver(args.getChannel(), future);
+            observer.onConnected(args);
             streamsClient.read(readReq, observer);
 
             return future;

--- a/src/main/java/io/kurrent/dbclient/AbstractSubscribePersistentSubscription.java
+++ b/src/main/java/io/kurrent/dbclient/AbstractSubscribePersistentSubscription.java
@@ -9,10 +9,13 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 
 abstract class AbstractSubscribePersistentSubscription {
+    private final static Logger logger = LoggerFactory.getLogger(AbstractSubscribePersistentSubscription.class);
     protected static final Persistent.ReadReq.Options.Builder defaultReadOptions;
     private final GrpcClient client;
     private final String group;
@@ -119,11 +122,20 @@ abstract class AbstractSubscribePersistentSubscription {
                                 return;
                             }
 
-                            String leaderHost = sre.getTrailers().get(Metadata.Key.of("leader-endpoint-host", Metadata.ASCII_STRING_MARSHALLER));
-                            String leaderPort = sre.getTrailers().get(Metadata.Key.of("leader-endpoint-port", Metadata.ASCII_STRING_MARSHALLER));
+                            Metadata trailers = sre.getTrailers();
+                            if (trailers != null) {
+                                String leaderHost = trailers.get(Metadata.Key.of("leader-endpoint-host", Metadata.ASCII_STRING_MARSHALLER));
+                                String leaderPort = trailers.get(Metadata.Key.of("leader-endpoint-port", Metadata.ASCII_STRING_MARSHALLER));
 
-                            if (leaderHost != null && leaderPort != null) {
-                                error = new NotLeaderException(leaderHost, Integer.valueOf(leaderPort));
+                                if (leaderHost != null && leaderPort != null) {
+                                    try {
+                                        int port = Integer.parseInt(leaderPort);
+                                        args.reportNewLeader(leaderHost, port);
+                                        error = new NotLeaderException(leaderHost, port);
+                                    } catch (RuntimeException ex) {
+                                        logger.warn("failed to handle leader change notification", ex);
+                                    }
+                                }
                             }
                         }
 

--- a/src/main/java/io/kurrent/dbclient/ReadResponseObserver.java
+++ b/src/main/java/io/kurrent/dbclient/ReadResponseObserver.java
@@ -172,9 +172,14 @@ class ReadResponseObserver implements ClientResponseObserver<StreamsOuterClass.R
                 String leaderPort = trailers.get(Metadata.Key.of("leader-endpoint-port", Metadata.ASCII_STRING_MARSHALLER));
 
                 if (leaderHost != null && leaderPort != null) {
-                    int port = Integer.parseInt(leaderPort);
-                    this.args.reportNewLeader(leaderHost, port);
-                    t = new NotLeaderException(leaderHost, port);
+                    try {
+                        int port = Integer.parseInt(leaderPort);
+                        if (this.args != null)
+                            this.args.reportNewLeader(leaderHost, port);
+                        t = new NotLeaderException(leaderHost, port);
+                    } catch (RuntimeException ex) {
+                        logger.warn("failed to handle leader change notification", ex);
+                    }
                 }
             }
         }

--- a/src/test/java/io/kurrent/dbclient/LeaderRedirectUnitTest.java
+++ b/src/test/java/io/kurrent/dbclient/LeaderRedirectUnitTest.java
@@ -6,19 +6,16 @@ import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Regression guard for the leader-change NPE. When a subscription's onError receives
- * leader-endpoint trailers (the NotLeader redirect), it must NOT throw and must still
- * deliver onCancelled to the listener so the application can react/reconnect.
- *
- * Before the fix, ReadResponseObserver.onError called this.args.reportNewLeader(...) with
- * args == null on the subscription path, throwing a NullPointerException before reaching
- * consumer.onCancelled(...) and swallowing the failure. This test constructs the observer
- * without onConnected (args == null, the worst case) to lock that behavior down.
+ * A NotLeader redirect on a subscription must not throw and must still deliver onCancelled.
+ * The bug: onError called reportNewLeader(...) on a null args, throwing before
+ * consumer.onCancelled(...) and swallowing the failure.
  */
 public class LeaderRedirectUnitTest {
     @Test
@@ -39,7 +36,7 @@ public class LeaderRedirectUnitTest {
             (id, ev, action) -> action.run()
         );
 
-        // Subscription path with args unset (worst case): must not NPE, must notify listener.
+        // no onConnected(): args stays null
         ReadResponseObserver observer = new ReadResponseObserver(SubscribeToStreamOptions.get(), consumer);
 
         Metadata trailers = new Metadata();
@@ -49,6 +46,42 @@ public class LeaderRedirectUnitTest {
 
         Assertions.assertDoesNotThrow(() -> observer.onError(leaderRedirect));
         Assertions.assertTrue(cancelledFired.get(), "onCancelled must fire on a leader redirect");
+        Assertions.assertTrue(cancelErr.get() instanceof NotLeaderException,
+            "listener should receive a NotLeaderException, got: " + cancelErr.get());
+    }
+
+    @Test
+    public void onErrorLeaderRedirectReportsNewLeaderWhenConnected() {
+        AtomicReference<Throwable> cancelErr = new AtomicReference<>();
+
+        SubscriptionStreamConsumer consumer = new SubscriptionStreamConsumer(
+            new SubscriptionListener() {
+                @Override
+                public void onCancelled(Subscription subscription, Throwable exception) {
+                    cancelErr.set(exception);
+                }
+            },
+            null,
+            new CompletableFuture<>(),
+            (id, ev, action) -> action.run()
+        );
+
+        LinkedBlockingQueue<Msg> queue = new LinkedBlockingQueue<>();
+        WorkItemArgs args = new WorkItemArgs(UUID.randomUUID(), null, null, null, queue);
+
+        ReadResponseObserver observer = new ReadResponseObserver(SubscribeToStreamOptions.get(), consumer);
+        observer.onConnected(args);
+
+        Metadata trailers = new Metadata();
+        trailers.put(Metadata.Key.of("leader-endpoint-host", Metadata.ASCII_STRING_MARSHALLER), "127.0.0.1");
+        trailers.put(Metadata.Key.of("leader-endpoint-port", Metadata.ASCII_STRING_MARSHALLER), "2113");
+
+        Assertions.assertDoesNotThrow(() ->
+            observer.onError(new StatusRuntimeException(Status.UNAVAILABLE, trailers)));
+
+        Msg enqueued = queue.poll();
+        Assertions.assertTrue(enqueued instanceof CreateChannel,
+            "leader redirect should enqueue a CreateChannel for the new leader, got: " + enqueued);
         Assertions.assertTrue(cancelErr.get() instanceof NotLeaderException,
             "listener should receive a NotLeaderException, got: " + cancelErr.get());
     }

--- a/src/test/java/io/kurrent/dbclient/LeaderRedirectUnitTest.java
+++ b/src/test/java/io/kurrent/dbclient/LeaderRedirectUnitTest.java
@@ -1,0 +1,55 @@
+package io.kurrent.dbclient;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Regression guard for the leader-change NPE. When a subscription's onError receives
+ * leader-endpoint trailers (the NotLeader redirect), it must NOT throw and must still
+ * deliver onCancelled to the listener so the application can react/reconnect.
+ *
+ * Before the fix, ReadResponseObserver.onError called this.args.reportNewLeader(...) with
+ * args == null on the subscription path, throwing a NullPointerException before reaching
+ * consumer.onCancelled(...) and swallowing the failure. This test constructs the observer
+ * without onConnected (args == null, the worst case) to lock that behavior down.
+ */
+public class LeaderRedirectUnitTest {
+    @Test
+    public void onErrorLeaderRedirectStillInvokesOnCancelled() {
+        AtomicBoolean cancelledFired = new AtomicBoolean(false);
+        AtomicReference<Throwable> cancelErr = new AtomicReference<>();
+
+        SubscriptionStreamConsumer consumer = new SubscriptionStreamConsumer(
+            new SubscriptionListener() {
+                @Override
+                public void onCancelled(Subscription subscription, Throwable exception) {
+                    cancelledFired.set(true);
+                    cancelErr.set(exception);
+                }
+            },
+            null,
+            new CompletableFuture<>(),
+            (id, ev, action) -> action.run()
+        );
+
+        // Subscription path with args unset (worst case): must not NPE, must notify listener.
+        ReadResponseObserver observer = new ReadResponseObserver(SubscribeToStreamOptions.get(), consumer);
+
+        Metadata trailers = new Metadata();
+        trailers.put(Metadata.Key.of("leader-endpoint-host", Metadata.ASCII_STRING_MARSHALLER), "127.0.0.1");
+        trailers.put(Metadata.Key.of("leader-endpoint-port", Metadata.ASCII_STRING_MARSHALLER), "2113");
+        StatusRuntimeException leaderRedirect = new StatusRuntimeException(Status.UNAVAILABLE, trailers);
+
+        Assertions.assertDoesNotThrow(() -> observer.onError(leaderRedirect));
+        Assertions.assertTrue(cancelledFired.get(), "onCancelled must fire on a leader redirect");
+        Assertions.assertTrue(cancelErr.get() instanceof NotLeaderException,
+            "listener should receive a NotLeaderException, got: " + cancelErr.get());
+    }
+}

--- a/src/test/java/io/kurrent/dbclient/MiscTests.java
+++ b/src/test/java/io/kurrent/dbclient/MiscTests.java
@@ -6,5 +6,5 @@ import org.junit.platform.suite.api.Suite;
 
 @Suite
 @SelectPackages("io.kurrent.dbclient.misc")
-@SelectClasses(SubscriptionStreamConsumerTests.class)
+@SelectClasses({SubscriptionStreamConsumerTests.class, LeaderRedirectUnitTest.class})
 public class MiscTests {}


### PR DESCRIPTION
## Problem

When a cluster leader changes (failover or re-election), a catch-up subscription would **silently stop delivering events with no `onCancelled` callback** — the application was never told the subscription had dropped, so any reconnect logic built on `onCancelled` never ran and the subscription stayed dead until the process was restarted.

This hits the **default** configuration: `nodePreference=leader` is the client default, so subscriptions request the leader out of the box and are exposed on any leader change. Persistent subscriptions could hit the same silent failure.

## Cause

On a leader change the server tells the client "I'm no longer the leader, reconnect here". The client tried to record that new leader but threw a `NullPointerException` internally, because the subscription path never set up the connection context the read path already uses. The NPE was thrown *before* `onCancelled` ran, so the error was swallowed instead of being reported.

## Fix

- Subscriptions now set up that connection context, so a leader change is handled exactly like reads already handle it: the client re-points to the new leader and `onCancelled` is always invoked with a `NotLeaderException`.
- Hardened both the catch-up and persistent subscription error paths so a failure while handling the redirect can never again suppress `onCancelled`.

Closes DEV-1817
